### PR TITLE
feat: Exception 관련 코드 및 ApiResponse 작성

### DIFF
--- a/src/main/kotlin/masterplanb/masterplanbbe/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/masterplanb/masterplanbbe/common/exception/ErrorCode.kt
@@ -1,0 +1,22 @@
+package masterplanb.masterplanbbe.common.exception
+
+enum class ErrorCode(val status: Int, val code: String, val message:String) {
+    // Common
+    BAD_REQUEST(400, "C001", "요청 파라미터 혹은 요청 바디의 값을 다시 확인하세요."),
+    INTERNAL_SERVER_ERROR(500, "C002", "Internal Server Error"),
+    INVALID_INPUT_VALUE(400, "C003", "유효하지 않은 입력입니다."),
+    DATETIME_INVALID(400, "C005", "유효하지 않은 날짜입니다"),
+    MESSAGE_SEND_FAIL(400, "C006", "메시지 전송 실패"),
+
+    // User
+    USER_NOT_FOUND(404, "U001", "사용자를 찾을 수 없습니다."),
+    SOME_USERS_NOT_FOUND(404, "U002", "일부 사용자를 찾을 수 없습니다."),
+    USER_ID_NOT_INITIALIZED(400, "U003", "사용자 ID가 초기화되지 않았습니다."),
+
+    // Auth
+    DUPLICATED_PHONE_NUMBER(409, "A001", "이미 등록된 전화번호입니다."),
+
+    // Oauth
+    SOCIAL_EMAIL_LOAD_FAIL(400, "O001", "소셜 로그인에서 이메일을 불러올 수 없습니다."),
+    SOCIAL_NAME_LOAD_FAIL(400, "O002", "소셜 로그인에서 이름을 불러올 수 없습니다."),
+}

--- a/src/main/kotlin/masterplanb/masterplanbbe/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/masterplanb/masterplanbbe/common/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,46 @@
+package masterplanb.masterplanbbe.common.exception
+
+import masterplanb.masterplanbbe.common.response.ErrorResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+
+@ControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(GlobalExceptions.NotFoundException::class)
+    fun handleNotfoundException(
+        e: GlobalExceptions.NotFoundException
+    ): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.valueOf(e.errorCode.status)).body(
+            ErrorResponse.of(e.errorCode)
+        )
+    }
+
+    @ExceptionHandler(GlobalExceptions.InternalErrorException::class)
+    fun handleInternalErrorException(
+        e: GlobalExceptions.InternalErrorException
+    ): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.valueOf(e.errorCode.status)).body(
+            ErrorResponse.of(e.errorCode)
+        )
+    }
+
+    @ExceptionHandler(GlobalExceptions.IllegalStateException::class)
+    fun handleIllegalStateException(
+        e: GlobalExceptions.IllegalStateException
+    ): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.valueOf(e.errorCode.status)).body(
+            ErrorResponse.of(e.errorCode)
+        )
+    }
+
+    @ExceptionHandler(GlobalExceptions.BadRequestException::class)
+    fun handleBadRequestException(
+        e: GlobalExceptions.BadRequestException
+    ): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.valueOf(e.errorCode.status)).body(
+            ErrorResponse.of(e.errorCode)
+        )
+    }
+}

--- a/src/main/kotlin/masterplanb/masterplanbbe/common/exception/GlobalExceptions.kt
+++ b/src/main/kotlin/masterplanb/masterplanbbe/common/exception/GlobalExceptions.kt
@@ -1,0 +1,9 @@
+package masterplanb.masterplanbbe.common.exception
+
+class GlobalExceptions {
+    open class GlobalException(val errorCode: ErrorCode): RuntimeException(errorCode.message)
+    class NotFoundException(errorCode: ErrorCode): GlobalException(errorCode)
+    class InternalErrorException(errorCode: ErrorCode): GlobalException(errorCode)
+    class IllegalStateException(errorCode: ErrorCode): GlobalException(errorCode)
+    class BadRequestException(errorCode: ErrorCode): GlobalException(errorCode)
+}

--- a/src/main/kotlin/masterplanb/masterplanbbe/common/response/ApiResponse.kt
+++ b/src/main/kotlin/masterplanb/masterplanbbe/common/response/ApiResponse.kt
@@ -1,0 +1,16 @@
+package masterplanb.masterplanbbe.common.response
+
+import org.springframework.http.HttpStatus
+
+data class ApiResponse<T> (
+    val status: Int = 200,
+    val message: String = "",
+    val data: T? = null
+) {
+
+    companion object {
+        fun <T> with(httpStatus: HttpStatus, message: String, data: T?): ApiResponse<T> {
+            return ApiResponse(status = httpStatus.value(), message = message, data = data)
+        }
+    }
+}

--- a/src/main/kotlin/masterplanb/masterplanbbe/common/response/ErrorResponse.kt
+++ b/src/main/kotlin/masterplanb/masterplanbbe/common/response/ErrorResponse.kt
@@ -1,0 +1,19 @@
+package masterplanb.masterplanbbe.common.response
+
+import masterplanb.masterplanbbe.common.exception.ErrorCode
+
+data class ErrorResponse(
+    val status: Int,
+    val message: String,
+    val code: String
+) {
+    companion object {
+        fun of(errorCode: ErrorCode): ErrorResponse {
+            return ErrorResponse(
+                status = errorCode.status,
+                message = errorCode.message,
+                code = errorCode.code
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Exception 관련 코드 

### ErrorCode

```kotlin
enum class ErrorCode(val status: Int, val code: String, val message:String) {
    // Common
    BAD_REQUEST(400, "C001", "요청 파라미터 혹은 요청 바디의 값을 다시 확인하세요."),
    INTERNAL_SERVER_ERROR(500, "C002", "Internal Server Error"),
    INVALID_INPUT_VALUE(400, "C003", "유효하지 않은 입력입니다."),
    DATETIME_INVALID(400, "C005", "유효하지 않은 날짜입니다"),
    MESSAGE_SEND_FAIL(400, "C006", "메시지 전송 실패"),

    // User
    USER_NOT_FOUND(404, "U001", "사용자를 찾을 수 없습니다."),
    SOME_USERS_NOT_FOUND(404, "U002", "일부 사용자를 찾을 수 없습니다."),
    USER_ID_NOT_INITIALIZED(400, "U003", "사용자 ID가 초기화되지 않았습니다."),

    // Auth
    DUPLICATED_PHONE_NUMBER(409, "A001", "이미 등록된 전화번호입니다."),

    // Oauth
    SOCIAL_EMAIL_LOAD_FAIL(400, "O001", "소셜 로그인에서 이메일을 불러올 수 없습니다."),
    SOCIAL_NAME_LOAD_FAIL(400, "O002", "소셜 로그인에서 이름을 불러올 수 없습니다."),
}
```

`ErrorCode`의 설계 목적은, message들을 한 enum class 안에 집적시켜서
빠르게 탐색하고 최대한 중복을 줄이는 것을 목표로 했습니다.

* `status`, `code`, `string`을 필드로 가지며,
  - `status`는 `ResponseEntity`의 Http Status를 초기화하는 데도 사용되고, 
조금 더 구체화돼있지 않은 정보를 제공할 때 사용할 수 있습니다.
  - `code`는 0부터 1씩 증가하는, 유일성을 나타내는 지표입니다.
  - `message`는 발생한 Exception의 내용을 설명합니다.

### GlobalExceptions
```kotlin
class GlobalExceptions {
    open class GlobalException(val errorCode: ErrorCode): RuntimeException(errorCode.message)
    class NotFoundException(errorCode: ErrorCode): GlobalException(errorCode)
    class InternalErrorException(errorCode: ErrorCode): GlobalException(errorCode)
    class IllegalStateException(errorCode: ErrorCode): GlobalException(errorCode)
    class BadRequestException(errorCode: ErrorCode): GlobalException(errorCode)
}
```

`GlobalExceptions`의 설계 목적은,
`errorCode: ErrorCode`를 유일한 인자로 해서 사용자 예외를 발생시킬 때 
`ErrorCode` enum 클래스로 이동하여 메시지를 작성하도록 강제함으로써, 
메시지 중복을 최소화하는 워크 플로우가 자연스럽게 이어질 수 있는 것을 목표로 했습니다.

### `ErrorResponse`와 `ExceptionHandler`
```kotlin
data class ErrorResponse(
    val status: Int,
    val message: String,
    val code: String
) {
    companion object {
        fun of(errorCode: ErrorCode): ErrorResponse {
            return ErrorResponse(
                status = errorCode.status,
                message = errorCode.message,
                code = errorCode.code
            )
        }
    }
}
```
```kotlin
class GlobalExceptionHandler {
    @ExceptionHandler(GlobalExceptions.NotFoundException::class)
    fun handleNotfoundException(
        e: GlobalExceptions.NotFoundException
    ): ResponseEntity<ErrorResponse> {
        return ResponseEntity.status(HttpStatus.valueOf(e.errorCode.status)).body(
            ErrorResponse.of(e.errorCode)
        )
    }
// ...
}
```
개발 편의를 위해 `ErrorCode`의 모든 값을 반환하며, 

`ResponseEntity.body`에서도 `ErrorResponse.of` 메서드를 통해
모든 필드를 초기화하도록 돼있습니다.
하지만 이들을 재정의함으로써 필요시 정보를 은닉할 수 있습니다.

## 예외 처리 흐름을 다시 요약하면 다음과 같습니다.
1. 예외 메시지는 ErrorCode 안에서 계속 추가되어, 중복을 검사하며 최소한으로 관리
2. GlobalExceptionHandler에서의 공통 처리를 검토, 세분화된 처리가 필요할 경우
별도의 handler에서 처리
3. handler 안에서 ResponseEntity.status와 ErrorResponse안에 들어갈 값을 검사.
개발 편의를 위해 ErrorCode 객체를 통해 모두 초기화하나, 은닉이 필요할 경우 재정의할 수 있다.

이상이 이번의 작업 내역입니다.