### PR TITLE
Feat/logging 로컬 스토리지 로깅 작성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,10 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // ## Logging
+    implementation("net.logstash.logback:logstash-logback-encoder:7.4")
+    implementation("org.springframework.boot:spring-boot-starter-logging:3.1.0")
 }
 
 kotlin {

--- a/src/main/kotlin/masterplanb/masterplanbbe/common/log/Logger.kt
+++ b/src/main/kotlin/masterplanb/masterplanbbe/common/log/Logger.kt
@@ -1,0 +1,5 @@
+package masterplanb.masterplanbbe.common.log
+
+import org.slf4j.LoggerFactory
+
+inline fun <reified T> T.logger() = LoggerFactory.getLogger(T::class.java)!!

--- a/src/main/kotlin/masterplanb/masterplanbbe/common/log/MDCRequestFilter.kt
+++ b/src/main/kotlin/masterplanb/masterplanbbe/common/log/MDCRequestFilter.kt
@@ -1,0 +1,23 @@
+package masterplanb.masterplanbbe.common.log
+
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletRequest
+import org.slf4j.MDC
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class MDCRequestFilter : Filter {
+    override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
+        val requestId = (request as HttpServletRequest).getHeader("X-RequestID")
+        MDC.put("requestId", requestId?.takeIf { it.isNotEmpty() } ?: UUID.randomUUID().toString().replace("-", ""))
+        chain.doFilter(request, response)
+        MDC.clear()
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="60 seconds" debug="false">
+  <!-- The conversion rules are copied from `logback\defaults.xml` -->
+  <conversionRule conversionWord="clr"
+    converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+  <conversionRule conversionWord="wex"
+    converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter"/>
+  <conversionRule conversionWord="wEx"
+    converterClass="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter"/>
+
+  <include resource="logback/console-appender.xml"/>
+  <include resource="logback/file-appender.xml"/>
+
+  <appender name="ASYNC_CONSOLE" class="ch.qos.logback.classic.AsyncAppender">
+    <!-- console-appender -->
+    <appender-ref ref="CONSOLE"/>
+    <includeCallerData>true</includeCallerData>
+    <discardingThreshold>0</discardingThreshold>
+    <queueSize>2048</queueSize>
+    <neverBlock>true</neverBlock>
+  </appender>
+  <appender name="ASYNC_FILE_ALL" class="ch.qos.logback.classic.AsyncAppender">
+    <!-- file-appender -->
+    <appender-ref ref="FILE_ALL"/>
+    <includeCallerData>true</includeCallerData>
+    <discardingThreshold>0</discardingThreshold>
+    <queueSize>2048</queueSize>
+    <neverBlock>true</neverBlock>
+  </appender>
+  <appender name="ASYNC_FILE_WARN" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="FILE_WARN"/>
+    <includeCallerData>true</includeCallerData>
+    <discardingThreshold>0</discardingThreshold>
+    <queueSize>1024</queueSize>
+    <neverBlock>true</neverBlock>
+  </appender>
+  <appender name="ASYNC_FILE_ERROR" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="FILE_ERROR"/>
+    <includeCallerData>true</includeCallerData>
+    <discardingThreshold>0</discardingThreshold>
+    <queueSize>1024</queueSize>
+    <neverBlock>true</neverBlock>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="ASYNC_CONSOLE"/>
+    <appender-ref ref="ASYNC_FILE_ALL"/>
+    <appender-ref ref="ASYNC_FILE_WARN"/>
+    <appender-ref ref="ASYNC_FILE_ERROR"/>
+  </root>
+
+  <logger name="org.springframework.security.config.annotation.web.builders.WebSecurity"
+    level="ERROR"/>
+  <logger name="org.springframework.security.web.DefaultSecurityFilterChain" level="ERROR"/>
+</configuration>

--- a/src/main/resources/logback/console-appender.xml
+++ b/src/main/resources/logback/console-appender.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+  <springProperty name="CONSOLE_LOG_PATTERN" source="logging.pattern.console"
+    defaultValue="%clr(%d{HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%25.25t]){faint} %clr([%-30.30logger]){cyan} %clr([%20.20M]){faint}  %clr([%X{X-TX-XID:-}]){faint} %clr(:){faint} %m%n%wEx"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+      <charset>UTF-8</charset>
+    </encoder>
+  </appender>
+</included>

--- a/src/main/resources/logback/file-appender.xml
+++ b/src/main/resources/logback/file-appender.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+  <!-- file-appender properties -->
+  <springProperty name="LOG_FILE_PATH" source="logging.file.path"
+    defaultValue="${user.home}/logs/master-plan-b"/>
+  <springProperty name="FILE_LOG_PATTERN" source="logging.pattern.file"
+    defaultValue="%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%t] [%logger] [%M] [%X{X-TX-XID:-}]: %m%n%wEx"/>
+
+  <!--ALL-->
+  <appender name="FILE_ALL" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOG_FILE_PATH}/${APPLICATION_NAME:-server}.all.log</file>
+    <append>true</append>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>
+        ${LOG_FILE_PATH}/history/${APPLICATION_NAME:-server}.all.%d{yyyy-MM-dd}.%i.log.gz
+      </fileNamePattern>
+      <maxFileSize>2GB</maxFileSize>
+      <MaxHistory>7</MaxHistory>
+      <totalSizeCap>7GB</totalSizeCap>
+      <cleanHistoryOnStart>true</cleanHistoryOnStart>
+    </rollingPolicy>
+    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+      <includeCallerData>true</includeCallerData>
+      <jsonGeneratorDecorator class="net.logstash.logback.decorate.CompositeJsonGeneratorDecorator">
+        <decorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator"/>
+        <decorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
+          <defaultMask>XXXX</defaultMask>
+          <path>password</path>
+        </decorator>
+      </jsonGeneratorDecorator>
+      <providers>
+        <logLevel>
+          <fieldName>level</fieldName>
+        </logLevel>
+        <pattern>
+          <pattern>
+            {"type":"%X{type:-application}"}
+          </pattern>
+        </pattern>
+        <timestamp>
+          <fieldName>timestamp</fieldName>
+          <timeZone>Asia/Seoul</timeZone>
+        </timestamp>
+        <mdc>
+          <includeMdcKeyName>requestId</includeMdcKeyName>
+        </mdc>
+        <message/>
+        <arguments/>
+        <stackTrace>
+          <fieldName>stackTrace</fieldName>
+        </stackTrace>
+      </providers>
+      <charset>UTF-8</charset>
+    </encoder>
+  </appender>
+
+  <!--WARN-->
+  <appender name="FILE_WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>WARN</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+    <file>${LOG_FILE_PATH}/${APPLICATION_NAME:-server}.warn.log</file>
+    <append>true</append>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>
+        ${LOG_FILE_PATH}/history/${APPLICATION_NAME:-server}.warn.%d{yyyy-MM-dd}.%i.log.gz
+      </fileNamePattern>
+      <maxFileSize>2GB</maxFileSize>
+      <MaxHistory>7</MaxHistory>
+      <totalSizeCap>7GB</totalSizeCap>
+      <cleanHistoryOnStart>true</cleanHistoryOnStart>
+    </rollingPolicy>
+    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+      <includeCallerData>true</includeCallerData>
+      <jsonGeneratorDecorator class="net.logstash.logback.decorate.CompositeJsonGeneratorDecorator">
+        <decorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator"/>
+        <decorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
+          <defaultMask>XXXX</defaultMask>
+          <path>password</path>
+        </decorator>
+      </jsonGeneratorDecorator>
+      <providers>
+        <logLevel>
+          <fieldName>level</fieldName>
+        </logLevel>
+        <pattern>
+          <pattern>
+            {"type":"%X{type:-application}"}
+          </pattern>
+        </pattern>
+        <timestamp>
+          <fieldName>timestamp</fieldName>
+          <timeZone>Asia/Seoul</timeZone>
+        </timestamp>
+        <mdc>
+          <includeMdcKeyName>requestId</includeMdcKeyName>
+        </mdc>
+        <message/>
+        <arguments/>
+        <stackTrace>
+          <fieldName>stackTrace</fieldName>
+        </stackTrace>
+      </providers>
+      <charset>UTF-8</charset>
+    </encoder>
+  </appender>
+
+  <!--ERROR-->
+  <appender name="FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>ERROR</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+    <file>${LOG_FILE_PATH}/${APPLICATION_NAME:-server}.error.log</file>
+    <append>true</append>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>
+        ${LOG_FILE_PATH}/history/${APPLICATION_NAME:-server}.error.%d{yyyy-MM-dd}.%i.log.gz
+      </fileNamePattern>
+      <maxFileSize>2GB</maxFileSize>
+      <MaxHistory>7</MaxHistory>
+      <totalSizeCap>7GB</totalSizeCap>
+      <cleanHistoryOnStart>true</cleanHistoryOnStart>
+    </rollingPolicy>
+    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+      <includeCallerData>true</includeCallerData>
+      <jsonGeneratorDecorator class="net.logstash.logback.decorate.CompositeJsonGeneratorDecorator">
+        <decorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator"/>
+        <decorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
+          <defaultMask>XXXX</defaultMask>
+          <path>password</path>
+        </decorator>
+      </jsonGeneratorDecorator>
+      <providers>
+        <logLevel>
+          <fieldName>level</fieldName>
+        </logLevel>
+        <pattern>
+          <pattern>
+            {"type":"%X{type:-application}"}
+          </pattern>
+        </pattern>
+        <timestamp>
+          <fieldName>timestamp</fieldName>
+          <timeZone>Asia/Seoul</timeZone>
+        </timestamp>
+        <mdc>
+          <includeMdcKeyName>requestId</includeMdcKeyName>
+        </mdc>
+        <message/>
+        <arguments/>
+        <stackTrace>
+          <fieldName>stackTrace</fieldName>
+        </stackTrace>
+      </providers>
+    </encoder>
+  </appender>
+</included>


### PR DESCRIPTION
## 변경 사항

### Logger 팩토리 메서드 작성
```kotlin
inline fun <reified T> T.logger() = LoggerFactory.getLogger(T::class.java)!!
```
`@Slf4j` 어노테이션을 대체하는 메서드입니다.
* Logging은 적용 위치에서 대부분 관심사가 아니고
* 이 어노테이션은 롬복 의존성이 있어서 대체했습니다.

팩토리 메서드를 AOP와 결합하면, 성능 오버헤드가 발생하지만,
클래스의 명세에서 logger의 선언을 뺄 수도 있습니다.

### MDC Request Filter 작성
```kotlin
@Component
@Order(Ordered.HIGHEST_PRECEDENCE)
class MDCRequestFilter : Filter {
    override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
        val requestId = (request as HttpServletRequest).getHeader("X-RequestID")
        MDC.put("requestId", requestId?.takeIf { it.isNotEmpty() } ?: UUID.randomUUID().toString().replace("-", ""))
        chain.doFilter(request, response)
        MDC.clear()
    }
}
```
요청 흐름을 추적하기 위해, 요청 ID를 남기는 코드를 작성했습니다.

### logback-spring.xml 및 appender 작성
console appender와 file appender는 분리하여 작성했습니다.
* 따라서 개발할 때의 로그는 행수에 비례해서 적은 스크롤로 조회할 수 있으며,
* 파일에 남기는 로그는
  - JSON 포맷으로 기록되어 machine readable 하고, 
  - 필드명마다 개행하여 시인성이 보다 향상되어 있으며,
  - 민감 정보인 필드는 마스킹하도록 되어 있습니다.

현재는 
```xml
<springProperty name="LOG_FILE_PATH" source="logging.file.path"
    defaultValue="${user.home}/logs/master-plan-b"/>
```
인스턴스 이하의 디렉터리를 만들고 로그 파일로 저장되게 되어 있지만,
이후 원격 저장소에 보관되도록 업데이트할 예정입니다.

이상이 이번의 변경 사항입니다.