### PR TITLE
jOOQ POJO로 반환 객체 수정

### DIFF
--- a/src/main/kotlin/masterplanb/masterplanbbe/MasterPlanBBeApplication.kt
+++ b/src/main/kotlin/masterplanb/masterplanbbe/MasterPlanBBeApplication.kt
@@ -2,8 +2,10 @@ package masterplanb.masterplanbbe
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
+@EnableJpaAuditing
 class MasterPlanBBeApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/masterplanb/masterplanbbe/user/repository/UserRepositoryCustom.kt
+++ b/src/main/kotlin/masterplanb/masterplanbbe/user/repository/UserRepositoryCustom.kt
@@ -1,6 +1,7 @@
 package masterplanb.masterplanbbe.user.repository
 
-import masterplanb.masterplanbbe.domain.User
+import org.jooq.generated.tables.pojos.User
+
 
 interface UserRepositoryCustom {
     fun findByUserId(userId: String): User?

--- a/src/main/kotlin/masterplanb/masterplanbbe/user/repository/UserRepositoryImpl.kt
+++ b/src/main/kotlin/masterplanb/masterplanbbe/user/repository/UserRepositoryImpl.kt
@@ -1,16 +1,19 @@
 package masterplanb.masterplanbbe.user.repository
 
-import masterplanb.masterplanbbe.domain.User
 import org.jooq.DSLContext
 import org.jooq.generated.tables.JUser.*
+import org.jooq.generated.tables.pojos.User
 
 class UserRepositoryImpl(
     private val dslContext: DSLContext
 ): UserRepositoryCustom {
     override fun findByUserId(userId: String): User? {
-        val query = dslContext.selectFrom(USER)
+        val query = dslContext.select(*USER.fields())
+            .from(USER)
             .where(USER.USER_ID.eq(userId))
 
-        return query.fetchOneInto(User::class.java)
+        val result = query.fetchOneInto(User::class.java)
+        println(result)
+        return result
     }
 }

--- a/src/main/kotlin/masterplanb/masterplanbbe/user/repository/UserRepositoryImpl.kt
+++ b/src/main/kotlin/masterplanb/masterplanbbe/user/repository/UserRepositoryImpl.kt
@@ -1,12 +1,16 @@
 package masterplanb.masterplanbbe.user.repository
 
-import jakarta.persistence.EntityManager
 import masterplanb.masterplanbbe.domain.User
+import org.jooq.DSLContext
+import org.jooq.generated.tables.JUser.*
 
 class UserRepositoryImpl(
-    em: EntityManager
+    private val dslContext: DSLContext
 ): UserRepositoryCustom {
     override fun findByUserId(userId: String): User? {
-        TODO("Not yet implemented")
+        val query = dslContext.selectFrom(USER)
+            .where(USER.USER_ID.eq(userId))
+
+        return query.fetchOneInto(User::class.java)
     }
 }

--- a/src/test/kotlin/fixture/UserFixture.kt
+++ b/src/test/kotlin/fixture/UserFixture.kt
@@ -1,0 +1,20 @@
+package fixture
+
+import masterplanb.masterplanbbe.domain.Role.*
+import masterplanb.masterplanbbe.domain.User
+import java.util.*
+
+class UserFixture {
+    companion object {
+        fun createUser(): User {
+            return User(
+                userId = UUID.randomUUID().toString(),
+                email = "test@test.com",
+                name = "test",
+                nickname = "test",
+                password = "test-password",
+                role = USER
+            )
+        }
+    }
+}

--- a/src/test/kotlin/masterplanb/masterplanbbe/user/repository/UserRepositoryTest.kt
+++ b/src/test/kotlin/masterplanb/masterplanbbe/user/repository/UserRepositoryTest.kt
@@ -18,12 +18,10 @@ class UserRepositoryTest @Autowired constructor(
         val foundUser = userRepository.findByUserId(user.userId)
 
         assertThat(foundUser!!.id).isNotNull
-/*
         assertThat(foundUser.userId).isEqualTo(user.userId)
         assertThat(foundUser.email).isEqualTo(user.email)
         assertThat(foundUser.name).isEqualTo(user.name)
         assertThat(foundUser.nickname).isEqualTo(user.nickname)
         assertThat(foundUser.password).isEqualTo(user.password)
-*/
     }
 }

--- a/src/test/kotlin/masterplanb/masterplanbbe/user/repository/UserRepositoryTest.kt
+++ b/src/test/kotlin/masterplanb/masterplanbbe/user/repository/UserRepositoryTest.kt
@@ -1,0 +1,29 @@
+package masterplanb.masterplanbbe.user.repository
+
+import fixture.UserFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class UserRepositoryTest @Autowired constructor(
+    private val userRepository: UserRepository
+) {
+    @Test
+    fun `user can be found by userId`() {
+        val user = userRepository.save(UserFixture.createUser())
+
+        val foundUser = userRepository.findByUserId(user.userId)
+
+        assertThat(foundUser!!.id).isNotNull
+/*
+        assertThat(foundUser.userId).isEqualTo(user.userId)
+        assertThat(foundUser.email).isEqualTo(user.email)
+        assertThat(foundUser.name).isEqualTo(user.name)
+        assertThat(foundUser.nickname).isEqualTo(user.nickname)
+        assertThat(foundUser.password).isEqualTo(user.password)
+*/
+    }
+}


### PR DESCRIPTION
* `@EnableJpaAuditing` 이 누락돼 있어 추가했습니다.
* UserFixture 를 추가했습니다.
- - -
- 테스트 중에 SELECT 구문 이후, BaseEntity에 적힌 필드 외에는 null이 매핑되는 것을 확인했습니다.  
  jOOQ는 setter를 사용하여 매핑하기 때문에 getter만 허용하는 필드들과 충돌했던 겁니다.
    
  [인프런 강의의 원본 코드](https://github.com/SightStudio/jOOQ-inflearn/blob/main/4.2_jOOQ-codegen-with-testcontainers-and-flyway-separate-ddl/src/main/java/org/sight/jooqstart/actor/ActorRepository.java)를 봐도 반환에 jOOQ 생성 POJO 객체를 쓰고 있는데,  
  reflection이나 proxy를 쓰지 않기 때문에 런타임에 성능상 유리하다고 합니다.


* 그래서 반환 객체를 jOOQ POJO로 설정했습니다.
* test에서 필드를 검사하면 DSL 코드들 일체가 최신화되는 효과도 있겠습니다.