### PR TITLE
refactor: ErrorResponse의 반환 필드를 ApiResponse와 같이 수정

### DIFF
--- a/src/main/kotlin/masterplanb/masterplanbbe/common/response/ErrorResponse.kt
+++ b/src/main/kotlin/masterplanb/masterplanbbe/common/response/ErrorResponse.kt
@@ -5,14 +5,14 @@ import masterplanb.masterplanbbe.common.exception.ErrorCode
 data class ErrorResponse(
     val status: Int,
     val message: String,
-    val code: String
+    val data:Unit? = null
 ) {
     companion object {
         fun of(errorCode: ErrorCode): ErrorResponse {
             return ErrorResponse(
                 status = errorCode.status,
                 message = errorCode.message,
-                code = errorCode.code
+                data = null
             )
         }
     }


### PR DESCRIPTION
두 가지 이유로 반환 필드를 바꿨습니다.
* ApiResponse와 ErrorResponse의 반환 필드 목록을 같이 하여, 사용을 편하게 하려는 의도
* code는 unique한 ENUM을 나타내기 때문에 은닉할 필요성이 있던 점

```kotlin
data class ErrorResponse(
    val status: Int,
    val message: String,
    val data:Unit? = null
) {
    companion object {
        fun of(errorCode: ErrorCode): ErrorResponse {
            return ErrorResponse(
                status = errorCode.status,
                message = errorCode.message,
                data = null
            )
        }
    }
 ```

반환 객체인 Unit은 값이 없는 상태를 나타낸다고 합니다. 