### PR TITLE
feat: nullability 표현을 위해 어노테이션 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 
 	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 	implementation 'org.springframework.boot:spring-boot-starter-logging:3.1.0'
+
+	// https://mvnrepository.com/artifact/com.google.code.findbugs/jsr305
+	implementation 'com.google.code.findbugs:jsr305:3.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/masterplanbbe/common/annotation/NonNull.java
+++ b/src/main/java/com/example/masterplanbbe/common/annotation/NonNull.java
@@ -1,0 +1,14 @@
+package com.example.masterplanbbe.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierNickname;
+
+@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+@Nonnull
+@TypeQualifierNickname
+public @interface NonNull {}

--- a/src/main/java/com/example/masterplanbbe/common/annotation/Nullable.java
+++ b/src/main/java/com/example/masterplanbbe/common/annotation/Nullable.java
@@ -1,0 +1,15 @@
+package com.example.masterplanbbe.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierNickname;
+import javax.annotation.meta.When;
+
+@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+@Nonnull(when = When.MAYBE)
+@TypeQualifierNickname
+public @interface Nullable {}


### PR DESCRIPTION
## 작업 내용

* 엔티티 내부에서 자기기술적인 표현을 위해,
nullablity를 나타내는
NonNull 어노테이션과 Nullable 어노테이션을 추가했습니다.
```java
package com.example.masterplanbbe.common.annotation;

@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.TYPE_USE})
@Retention(RetentionPolicy.RUNTIME)
@Nonnull
@TypeQualifierNickname
public @interface NonNull {}
```

```java
package com.example.masterplanbbe.common.annotation;

@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.TYPE_USE})
@Retention(RetentionPolicy.RUNTIME)
@Nonnull(when = When.MAYBE)
@TypeQualifierNickname
public @interface Nullable {}
```

코드 출처는 [이 글](https://tech.inflab.com/20240110-java-and-kotlin/#custom-nullability-annotations)을 참고했습니다.
작업 범위에서 자율적으로 적용해주시면 됩니다.

* 의존성은 [링크](https://simple-ing.tistory.com/48)에 따라 추가했습니다.