### PR TITLE
Feat/study log:: 계층 구조에 따른 빈 클래스 파일 작성

### DIFF
--- a/src/main/java/com/example/masterplanbbe/studyLog/controller/StudyLogController.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/controller/StudyLogController.java
@@ -1,0 +1,13 @@
+package com.example.masterplanbbe.studyLog.controller;
+
+import com.example.masterplanbbe.studyLog.service.StudyLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/study-log")
+public class StudyLogController {
+    private final StudyLogService studyLogService;
+}

--- a/src/main/java/com/example/masterplanbbe/studyLog/entity/StudyLog.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/entity/StudyLog.java
@@ -23,7 +23,8 @@ public class StudyLog extends BaseEntity {
     private LocalDate studyDate;
 
 /*
-    @Column
+    @ManyToOne
+    @JoinColumn(name = "exam_id")
     private Exam exam;
 */
 

--- a/src/main/java/com/example/masterplanbbe/studyLog/entity/StudyLog.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/entity/StudyLog.java
@@ -1,0 +1,49 @@
+package com.example.masterplanbbe.studyLog.entity;
+
+import com.example.masterplanbbe.common.annotation.NonNull;
+import com.example.masterplanbbe.common.annotation.Nullable;
+import com.example.masterplanbbe.common.domain.BaseEntity;
+import com.example.masterplanbbe.studyLog.enums.InputSource;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "study_log")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyLog extends BaseEntity {
+    @NonNull
+    @Column
+    private LocalDate studyDate;
+
+/*
+    @Column
+    private Exam exam;
+*/
+
+    @Nullable
+    @Column
+    private String subject;
+
+    @Nullable
+    @Column
+    private Integer elapsedTime;
+
+    @Column
+    private String title;
+
+    @Column
+    private String content;
+
+    @NonNull
+    @Column
+    @Enumerated(EnumType.STRING)
+    private InputSource inputSource;
+}
+

--- a/src/main/java/com/example/masterplanbbe/studyLog/enums/InputSource.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/enums/InputSource.java
@@ -1,0 +1,6 @@
+package com.example.masterplanbbe.studyLog.enums;
+
+public enum InputSource {
+    COMPUTER,
+    MOBILE
+}

--- a/src/main/java/com/example/masterplanbbe/studyLog/repository/StudyLogRepository.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/repository/StudyLogRepository.java
@@ -1,0 +1,7 @@
+package com.example.masterplanbbe.studyLog.repository;
+
+import com.example.masterplanbbe.studyLog.entity.StudyLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyLogRepository extends JpaRepository<StudyLog, Long>, StudyLogRepositoryCustom {
+}

--- a/src/main/java/com/example/masterplanbbe/studyLog/repository/StudyLogRepositoryCustom.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/repository/StudyLogRepositoryCustom.java
@@ -1,0 +1,5 @@
+package com.example.masterplanbbe.studyLog.repository;
+
+public interface StudyLogRepositoryCustom {
+    // JpaRepository 가 생성하지 않는, 커스텀 메소드를 정의하는 인터페이스
+}

--- a/src/main/java/com/example/masterplanbbe/studyLog/repository/StudyLogRepositoryImpl.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/repository/StudyLogRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.example.masterplanbbe.studyLog.repository;
+
+public class StudyLogRepositoryImpl implements StudyLogRepositoryCustom {
+}

--- a/src/main/java/com/example/masterplanbbe/studyLog/service/StudyLogService.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/service/StudyLogService.java
@@ -1,0 +1,11 @@
+package com.example.masterplanbbe.studyLog.service;
+
+import com.example.masterplanbbe.studyLog.repository.StudyLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StudyLogService {
+    private final StudyLogRepository studyLogRepository;
+}


### PR DESCRIPTION
## 작업 내용

기존 컨벤션에 해당하는,
패키지 구조 설명을 위해 빈 클래스 파일을 작성했습니다.

## 구조 설명

```java
public interface StudyLogRepository extends JpaRepository<StudyLog, Long>, StudyLogRepositoryCustom {
}
```
* 학습 기록 테이블에 대응되는, `StudyLogRepository` 인터페이스는 
JpaRepository 인터페이스를 상속함으로써 Spring Data Jpa가 구현하는 메서드들을 사용할 수 있습니다.

```java
public interface StudyLogRepositoryCustom {
}

public class StudyLogRepositoryImpl implements StudyLogRepositoryCustom {
}
```
* `StudyLog Repository`는 JpaRepository 외에도
`StudyLogRepositoryCustom` 인터페이스를 상속하는데요.
Spring Data JPA가 구현해주지 않는, 복잡한 쿼리를 위한 인터페이스입니다.

## 동작 설명

어플리케이션이 시작하면, 
Spring은 리포지토리 인터페이스를 스캔해서
기본 CRUD 메서드는 `SimpleJpaRepository` 에 구현체를 위임하고
커스텀 메서드는 postfix가 붙은 구현체, `StudyLogRepositoryCustomImpl` 에 위임합니다.

## 결과
```java
@Service
@RequiredArgsConstructor
public class StudyLogService {
    private final StudyLogRepository studyLogRepository;
}
```
하나의 객체 참조자로 두 개 인터페이스의 메서드를 모두 쓸 수 있습니다.

- - -

[참고자료: Spring Boot에서 JPA Repository와 Custom Repository를 통합하여 사용하는 방법](https://velog.io/@gclee/Spring-Boot%EC%97%90%EC%84%9C-JPA-Repository%EC%99%80-Custom-Repository%EB%A5%BC-%ED%86%B5%ED%95%A9%ED%95%98%EC%97%AC-%EC%82%AC%EC%9A%A9%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95)