### PR TITLE
feat: 컨트롤러 create 메서드 작성

### DIFF
--- a/src/main/java/com/example/masterplanbbe/studyLog/controller/StudyLogController.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/controller/StudyLogController.java
@@ -1,13 +1,27 @@
 package com.example.masterplanbbe.studyLog.controller;
 
+import com.example.masterplanbbe.common.response.ApiResponse;
+import com.example.masterplanbbe.studyLog.request.CreateStudyLogRequest;
+import com.example.masterplanbbe.studyLog.response.CreateStudyLogResponse;
 import com.example.masterplanbbe.studyLog.service.StudyLogService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.example.masterplanbbe.studyLog.response.CreateStudyLogResponse.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/study-log")
 public class StudyLogController {
     private final StudyLogService studyLogService;
+
+    public ResponseEntity<ApiResponse<CreateStudyLogResponse>> createStudyLog(
+            @RequestBody CreateStudyLogRequest request
+    ) {
+        CreateStudyLogResponse response = of(studyLogService.createStudyLog(request));
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
 }

--- a/src/main/java/com/example/masterplanbbe/studyLog/controller/StudyLogController.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/controller/StudyLogController.java
@@ -10,8 +10,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.example.masterplanbbe.studyLog.response.CreateStudyLogResponse.*;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/study-log")
@@ -21,7 +19,7 @@ public class StudyLogController {
     public ResponseEntity<ApiResponse<CreateStudyLogResponse>> createStudyLog(
             @RequestBody CreateStudyLogRequest request
     ) {
-        CreateStudyLogResponse response = of(studyLogService.createStudyLog(request));
-        return ResponseEntity.ok(ApiResponse.ok(response));
+        return ResponseEntity.ok()
+                .body(ApiResponse.ok(studyLogService.createStudyLog(request)));
     }
 }

--- a/src/main/java/com/example/masterplanbbe/studyLog/request/CreateStudyLogRequest.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/request/CreateStudyLogRequest.java
@@ -1,0 +1,26 @@
+package com.example.masterplanbbe.studyLog.request;
+
+import com.example.masterplanbbe.studyLog.entity.StudyLog;
+import com.example.masterplanbbe.studyLog.enums.InputSource;
+
+import java.time.LocalDate;
+
+public record CreateStudyLogRequest(
+        LocalDate studyDate,
+        String subject,
+        Integer elapsedTime,
+        String title,
+        String content,
+        InputSource inputSource
+) {
+    public StudyLog toEntity() {
+        return new StudyLog(
+                studyDate,
+                subject,
+                elapsedTime,
+                title,
+                content,
+                inputSource
+        );
+    }
+}

--- a/src/main/java/com/example/masterplanbbe/studyLog/response/CreateStudyLogResponse.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/response/CreateStudyLogResponse.java
@@ -1,0 +1,29 @@
+package com.example.masterplanbbe.studyLog.response;
+
+import com.example.masterplanbbe.studyLog.entity.StudyLog;
+import com.example.masterplanbbe.studyLog.enums.InputSource;
+
+import java.time.LocalDate;
+
+
+public record CreateStudyLogResponse(
+        Long id,
+        LocalDate studyDate,
+        String subject,
+        Integer elapsedTime,
+        String title,
+        String content,
+        InputSource inputSource
+) {
+    public static CreateStudyLogResponse of(StudyLog studyLog) {
+        return new CreateStudyLogResponse (
+                studyLog.getId(),
+                studyLog.getStudyDate(),
+                studyLog.getSubject(),
+                studyLog.getElapsedTime(),
+                studyLog.getTitle(),
+                studyLog.getContent(),
+                studyLog.getInputSource()
+        );
+    }
+}

--- a/src/main/java/com/example/masterplanbbe/studyLog/response/CreateStudyLogResponse.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/response/CreateStudyLogResponse.java
@@ -15,8 +15,8 @@ public record CreateStudyLogResponse(
         String content,
         InputSource inputSource
 ) {
-    public static CreateStudyLogResponse of(StudyLog studyLog) {
-        return new CreateStudyLogResponse (
+    public CreateStudyLogResponse(StudyLog studyLog) {
+        this(
                 studyLog.getId(),
                 studyLog.getStudyDate(),
                 studyLog.getSubject(),

--- a/src/main/java/com/example/masterplanbbe/studyLog/service/StudyLogService.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/service/StudyLogService.java
@@ -1,6 +1,8 @@
 package com.example.masterplanbbe.studyLog.service;
 
+import com.example.masterplanbbe.studyLog.entity.StudyLog;
 import com.example.masterplanbbe.studyLog.repository.StudyLogRepository;
+import com.example.masterplanbbe.studyLog.request.CreateStudyLogRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -8,4 +10,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class StudyLogService {
     private final StudyLogRepository studyLogRepository;
+
+    public StudyLog createStudyLog(CreateStudyLogRequest request) {
+        return studyLogRepository.save(request.toEntity());
+    }
 }

--- a/src/main/java/com/example/masterplanbbe/studyLog/service/StudyLogService.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/service/StudyLogService.java
@@ -12,6 +12,6 @@ public class StudyLogService {
     private final StudyLogRepository studyLogRepository;
 
     public CreateStudyLogResponse createStudyLog(CreateStudyLogRequest request) {
-        return CreateStudyLogResponse.of(studyLogRepository.save(request.toEntity()));
+        return new CreateStudyLogResponse(studyLogRepository.save(request.toEntity()));
     }
 }

--- a/src/main/java/com/example/masterplanbbe/studyLog/service/StudyLogService.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/service/StudyLogService.java
@@ -1,8 +1,8 @@
 package com.example.masterplanbbe.studyLog.service;
 
-import com.example.masterplanbbe.studyLog.entity.StudyLog;
 import com.example.masterplanbbe.studyLog.repository.StudyLogRepository;
 import com.example.masterplanbbe.studyLog.request.CreateStudyLogRequest;
+import com.example.masterplanbbe.studyLog.response.CreateStudyLogResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 public class StudyLogService {
     private final StudyLogRepository studyLogRepository;
 
-    public StudyLog createStudyLog(CreateStudyLogRequest request) {
-        return studyLogRepository.save(request.toEntity());
+    public CreateStudyLogResponse createStudyLog(CreateStudyLogRequest request) {
+        return CreateStudyLogResponse.of(studyLogRepository.save(request.toEntity()));
     }
 }


### PR DESCRIPTION
## 작업 의도

### 1. Request와 Response
Request와 Response는 레코드로 만들었습니다.
불변성에서 어긋나는 일이 없을 거 같아 그렇게 했습니다.

그리고 변환 책임은 request와 response DTO가 가지도록 했습니다.

```java
package com.example.masterplanbbe.studyLog.request;

public record CreateStudyLogRequest(
        LocalDate studyDate,
        String subject,
        Integer elapsedTime,
        String title,
        String content,
        InputSource inputSource
) {
    public StudyLog toEntity() {
        return new StudyLog(
                studyDate,
                subject,
                elapsedTime,
                title,
                content,
                inputSource
        );
    }
}
```

```java
package com.example.masterplanbbe.studyLog.response;

public record CreateStudyLogResponse(
        Long id,
        LocalDate studyDate,
        String subject,
        Integer elapsedTime,
        String title,
        String content,
        InputSource inputSource
) {
    public CreateStudyLogResponse(StudyLog studyLog) {
        this(
                studyLog.getId(),
                studyLog.getStudyDate(),
                studyLog.getSubject(),
                studyLog.getElapsedTime(),
                studyLog.getTitle(),
                studyLog.getContent(),
                studyLog.getInputSource()
        );
    }
}
```

### 2. 컨트롤러 메서드

```java
package com.example.masterplanbbe.studyLog.controller;

public ResponseEntity<ApiResponse<CreateStudyLogResponse>> createStudyLog(
            @RequestBody CreateStudyLogRequest request
    ) {
        return ResponseEntity.ok()
                .body(ApiResponse.ok(studyLogService.createStudyLog(request)));
    }
```

이전의 PR인 공통 응답 객체, ApiResponse를 이와 같이 반영했습니다.

좀 어색해보이는 면은 있지만, 
* `ApiReponse` 객체가 `ResponseEntity`와 같은 속성
`status`, `message`, `data` 필드를 가지고 있고

* 객체 그래프를 생각했을 때
`response.body.status` 같은 형태로 나타난다는 점이
컨트롤러 메서드만 봤을 때도 분명히 보이는 게 좋을 거 같아
이렇게 결정했습니다.