### PR TITLE
feat: BeseEntity를 FullAuditEntity와 IdAndCreatedEntity로 분리

### DIFF
--- a/src/main/java/com/example/masterplanbbe/common/domain/FullAuditEntity.java
+++ b/src/main/java/com/example/masterplanbbe/common/domain/FullAuditEntity.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @SuperBuilder
 @Getter
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseEntity {
+public abstract class FullAuditEntity {
 
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/masterplanbbe/common/domain/IdAndCreatedEntity.java
+++ b/src/main/java/com/example/masterplanbbe/common/domain/IdAndCreatedEntity.java
@@ -1,0 +1,35 @@
+package com.example.masterplanbbe.common.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class IdAndCreatedEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/example/masterplanbbe/exam/entity/Exam.java
+++ b/src/main/java/com/example/masterplanbbe/exam/entity/Exam.java
@@ -1,7 +1,7 @@
 package com.example.masterplanbbe.exam.entity;
 
 import com.example.masterplanbbe.common.annotation.NonNull;
-import com.example.masterplanbbe.common.domain.BaseEntity;
+import com.example.masterplanbbe.common.domain.FullAuditEntity;
 import com.example.masterplanbbe.exam.enums.Category;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Exam extends BaseEntity {
+public class Exam extends FullAuditEntity {
     @NonNull
     @Column
     private String title;

--- a/src/main/java/com/example/masterplanbbe/exam/entity/ExamBookmark.java
+++ b/src/main/java/com/example/masterplanbbe/exam/entity/ExamBookmark.java
@@ -1,7 +1,7 @@
 package com.example.masterplanbbe.exam.entity;
 
 import com.example.masterplanbbe.common.annotation.NonNull;
-import com.example.masterplanbbe.common.domain.BaseEntity;
+import com.example.masterplanbbe.common.domain.IdAndCreatedEntity;
 import com.example.masterplanbbe.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -11,7 +11,7 @@ import lombok.*;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ExamBookmark extends BaseEntity {
+public class ExamBookmark extends IdAndCreatedEntity {
     @NonNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/example/masterplanbbe/exam/entity/ExamSession.java
+++ b/src/main/java/com/example/masterplanbbe/exam/entity/ExamSession.java
@@ -1,7 +1,7 @@
 package com.example.masterplanbbe.exam.entity;
 
 import com.example.masterplanbbe.common.annotation.NonNull;
-import com.example.masterplanbbe.common.domain.BaseEntity;
+import com.example.masterplanbbe.common.domain.FullAuditEntity;
 import com.example.masterplanbbe.exam.enums.SessionType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -16,7 +16,7 @@ import java.time.LocalDate;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ExamSession extends BaseEntity {
+public class ExamSession extends FullAuditEntity {
     @NonNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "exam_id")

--- a/src/main/java/com/example/masterplanbbe/exam/entity/Subject.java
+++ b/src/main/java/com/example/masterplanbbe/exam/entity/Subject.java
@@ -1,7 +1,7 @@
 package com.example.masterplanbbe.exam.entity;
 
 import com.example.masterplanbbe.common.annotation.NonNull;
-import com.example.masterplanbbe.common.domain.BaseEntity;
+import com.example.masterplanbbe.common.domain.FullAuditEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Subject extends BaseEntity {
+public class Subject extends FullAuditEntity {
     @NonNull
     @ManyToOne
     @JoinColumn(name = "exam_id")

--- a/src/main/java/com/example/masterplanbbe/member/entity/Member.java
+++ b/src/main/java/com/example/masterplanbbe/member/entity/Member.java
@@ -1,6 +1,6 @@
 package com.example.masterplanbbe.member.entity;
 
-import com.example.masterplanbbe.common.domain.BaseEntity;
+import com.example.masterplanbbe.common.domain.FullAuditEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -13,6 +13,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member extends BaseEntity {
+public class Member extends FullAuditEntity {
     private String userId;
 }

--- a/src/main/java/com/example/masterplanbbe/studyLog/entity/StudyLog.java
+++ b/src/main/java/com/example/masterplanbbe/studyLog/entity/StudyLog.java
@@ -2,7 +2,7 @@ package com.example.masterplanbbe.studyLog.entity;
 
 import com.example.masterplanbbe.common.annotation.NonNull;
 import com.example.masterplanbbe.common.annotation.Nullable;
-import com.example.masterplanbbe.common.domain.BaseEntity;
+import com.example.masterplanbbe.common.domain.FullAuditEntity;
 import com.example.masterplanbbe.studyLog.enums.InputSource;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -17,7 +17,7 @@ import java.time.LocalDate;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class StudyLog extends BaseEntity {
+public class StudyLog extends FullAuditEntity {
     @NonNull
     @Column
     private LocalDate studyDate;


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

스키마에 맞춰 필요한 audit 컬럼만 들어가도록,

상속받는 엔티티의 이름을 `FullAuditEntity`로 변경하고
`id`와 `created`만 들어간 추상 클래스를 추가해서 `IdAndCreatedEntity`로 이름지었습니다.

```java
@Getter
@AllArgsConstructor
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class ExamBookmark extends IdAndCreatedEntity {
    @NonNull
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "member_id")
    private Member member;
    @NonNull
    @OneToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "exam_id")
    private Exam exam;
}
```