### PR TITLE
fix: 클래스명 변경 반영 및 중복된 enum 제거

### DIFF
--- a/src/main/java/com/example/masterplanbbe/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/masterplanbbe/common/exception/ErrorCode.java
@@ -29,9 +29,7 @@ public enum ErrorCode {
     // Post
     INVALID_INPUT_TITLE(400,"P001","유효하지 않은 타이틀입니다."),
     INVALID_INPUT_CONTENT(400,"P002","유효하지 않은 내용입니다."),
-    NOT_FIND_POST(400,"P003" ,"게시글을 찾을 수 없습니다." ),
-
-    SOCIAL_NAME_LOAD_FAIL(400, "O002", "소셜 로그인에서 이름을 불러올 수 없습니다.");
+    NOT_FIND_POST(400,"P003" ,"게시글을 찾을 수 없습니다." );
 
     private final Integer status;
     private final String code;

--- a/src/main/java/com/example/masterplanbbe/domain/post/entity/Post.java
+++ b/src/main/java/com/example/masterplanbbe/domain/post/entity/Post.java
@@ -1,6 +1,6 @@
 package com.example.masterplanbbe.domain.post.entity;
 
-import com.example.masterplanbbe.common.domain.BaseEntity;
+import com.example.masterplanbbe.common.domain.FullAuditEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,7 +9,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Post extends BaseEntity {
+public class Post extends FullAuditEntity {
 
     private String title;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

* 이름이 변경됐던 추상 클래스 `FullAuditEntity`가
`Post`에서도 상속 받도록 변경했습니다.

* 중복됐던 enum이 있어 이를 삭제했습니다.
```java
SOCIAL_NAME_LOAD_FAIL(400, "O002", "소셜 로그인에서 이름을 불러올 수 없습니다.");
```