### PR TITLE
chore: idea 플러그인 추가 및 generated source root 관련 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.1'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'idea'
 }
 
 group = 'com.example'
@@ -49,14 +50,33 @@ tasks.withType(JavaCompile).configureEach {
 	options.generatedSourceOutputDirectory = file("$projectDir/src/main/generated")
 }
 
-//FIXME: src/main/generated 디렉토리를 IDEA 에서 mark as generated sources 로 설정할 것
+//QClass 파일 인식 불가시, src/main/generated 디렉토리를 IDEA 에서, mark as generated source root 로 설정할 것
+def generatedDir = file("$projectDir/src/main/generated")
+
+sourceSets {
+	main {
+		java {
+			srcDir generatedDir
+		}
+	}
+}
+
+tasks.named('clean') {
+	delete -= generatedDir
+}
+
 tasks.register('generateQueryDSL') {
 	doLast {
-		def generatedDir = file("$projectDir/src/main/generated")
 		if (!generatedDir.exists()) {
 			generatedDir.mkdirs()
 		}
 		sourceSets.main.java.srcDirs += generatedDir
+	}
+}
+
+idea {
+	module {
+		generatedSourceDirs += generatedDir
 	}
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

이전 [PR: Chore/adapting query dsl #23](https://github.com/fastcam-sideproject/BE-master-plan-b/pull/23)에서
`idea`의 두 가지 동작, 
`invalidate caches and restart`와 `Sync All Gradle Projects`를 시행한 후에는
`src/main/generated` 디렉토리의 `generated source root` 설정이 풀려버렸으나,

* 현재 설정을 적용하고

![image](https://github.com/user-attachments/assets/17285ed4-0dd1-414c-a708-b03296d9bdce)
* Build tools 설정을 IDEA로 변경해주었더니

`generated source root` 설정이 풀리지 않게 되었습니다.
즉 최초로 idea에서 설정한 이후로는 QueryDSL이 생성한 DSL 파일, 
QClass 파일을 이용할 수 있게 되므로 
해결된 거 같습니다.