### PR TITLE
chore: task 이름 수정 및 srcDirs 등록 누락 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,18 +46,16 @@ dependencies {
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
-tasks.withType(JavaCompile).configureEach {
-	options.generatedSourceOutputDirectory = file("$projectDir/src/main/generated")
-}
-
 //QClass 파일 인식 불가시, src/main/generated 디렉토리를 IDEA 에서, mark as generated source root 로 설정할 것
 def generatedDir = file("$projectDir/src/main/generated")
 
+tasks.withType(JavaCompile).configureEach {
+	options.generatedSourceOutputDirectory = generatedDir
+}
+
 sourceSets {
 	main {
-		java {
-			srcDir generatedDir
-		}
+		java.srcDirs += generatedDir
 	}
 }
 
@@ -65,7 +63,8 @@ tasks.named('clean') {
 	delete -= generatedDir
 }
 
-tasks.register('generateQueryDSL') {
+tasks.register('setupGeneratedDir') {
+	group = 'hidden'
 	doLast {
 		if (!generatedDir.exists()) {
 			generatedDir.mkdirs()
@@ -81,7 +80,7 @@ idea {
 }
 
 tasks.named("compileJava") {
-	dependsOn("generateQueryDSL")
+	dependsOn("setupGeneratedDir")
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

```gradle
def generatedDir = file("$projectDir/src/main/generated")
```
* `generatedDir` 변수를 gradle 파일 내의 다른 task 들이 참조하도록 해서
어떤 내용들이 QueryDSL과 연관된 작업인가 알 수 있도록 했습니다.

* `srcDirs` 설정이 오입력으로 누락돼 있었어서,
`@QueryProjection` 어노테이션으로 인한 빌드 파일은 다른 디렉터리에 출력되고 있었습니다.
이를 해결했습니다.

```gradle
tasks.register('setupGeneratedDir') {
	group = 'hidden'
	doLast {
		if (!generatedDir.exists()) {
			generatedDir.mkdirs()
		sourceSets.main.java.srcDirs += generatedDir
	}
}
```
* gradle 태스크의 이름을 변경했습니다. 
첨부된 코드는 generated source root로 등록되기 이전에 디렉터리 생성을 보장하고 
`sourceSets`에 등록하는 사전 작업입니다. 
따라서 `generateQueryDSL`이라는 무관한 이름에서 `setupGeneratedDir`이라는 직관적인 이름으로 바꾸었습니다.