### PR TITLE
feat: getAllExam에 페이지네이션 반영

### DIFF
--- a/src/main/java/com/example/masterplanbbe/common/domain/FullAuditEntity.java
+++ b/src/main/java/com/example/masterplanbbe/common/domain/FullAuditEntity.java
@@ -19,7 +19,6 @@ import java.time.LocalDateTime;
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 public abstract class FullAuditEntity {
-
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
         private Long id;
@@ -33,4 +32,9 @@ public abstract class FullAuditEntity {
         @Column(name = "updated_at")
         @Temporal(TemporalType.TIMESTAMP)
         private LocalDateTime modifiedAt;
+
+        @PrePersist
+        public void prePersist() {
+                this.modifiedAt = LocalDateTime.now();
+        }
 }

--- a/src/main/java/com/example/masterplanbbe/exam/controller/ExamController.java
+++ b/src/main/java/com/example/masterplanbbe/exam/controller/ExamController.java
@@ -5,6 +5,7 @@ import com.example.masterplanbbe.exam.dto.ExamItemCardDto;
 import com.example.masterplanbbe.exam.response.ReadAllExamResponse;
 import com.example.masterplanbbe.exam.response.ReadExamResponse;
 import com.example.masterplanbbe.exam.service.ExamService;
+import com.example.masterplanbbe.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,10 +25,10 @@ public class ExamController {
     @GetMapping
     public ResponseEntity<ApiResponse<Page<ExamItemCardDto>>> getAllExam(
             @PageableDefault Pageable pageable,
-            Long memberId //TODO: security context로 변경
+            Member member//TODO: security context로 변경
     ) {
         return ResponseEntity.ok()
-                .body(ApiResponse.ok(examService.getAllExam(pageable, memberId)));
+                .body(ApiResponse.ok(examService.getAllExam(pageable, member.getUserId())));
     }
 
     @GetMapping("/{examId}")

--- a/src/main/java/com/example/masterplanbbe/exam/controller/ExamController.java
+++ b/src/main/java/com/example/masterplanbbe/exam/controller/ExamController.java
@@ -1,10 +1,14 @@
 package com.example.masterplanbbe.exam.controller;
 
 import com.example.masterplanbbe.common.response.ApiResponse;
+import com.example.masterplanbbe.exam.dto.ExamItemCardDto;
 import com.example.masterplanbbe.exam.response.ReadAllExamResponse;
 import com.example.masterplanbbe.exam.response.ReadExamResponse;
 import com.example.masterplanbbe.exam.service.ExamService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,11 +22,12 @@ public class ExamController {
     private final ExamService examService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<ReadAllExamResponse>> getAllExam(
+    public ResponseEntity<ApiResponse<Page<ExamItemCardDto>>> getAllExam(
+            @PageableDefault Pageable pageable,
             Long memberId //TODO: security context로 변경
     ) {
         return ResponseEntity.ok()
-                .body(ApiResponse.ok(examService.getAllExam(memberId)));
+                .body(ApiResponse.ok(examService.getAllExam(pageable, memberId)));
     }
 
     @GetMapping("/{examId}")

--- a/src/main/java/com/example/masterplanbbe/exam/dto/ExamItemCardDto.java
+++ b/src/main/java/com/example/masterplanbbe/exam/dto/ExamItemCardDto.java
@@ -2,6 +2,7 @@ package com.example.masterplanbbe.exam.dto;
 
 import com.example.masterplanbbe.exam.entity.Exam;
 import com.example.masterplanbbe.exam.enums.Category;
+import com.querydsl.core.annotations.QueryProjection;
 
 public record ExamItemCardDto (
         String title,
@@ -10,6 +11,7 @@ public record ExamItemCardDto (
         Integer participants,
         Boolean isBookmarked
 ) {
+    @QueryProjection
     public ExamItemCardDto(Exam exam, Boolean isBookmarked) {
         this(exam.getTitle(), exam.getCategory(), exam.getDifficulty(), exam.getParticipantCount(), isBookmarked);
     }

--- a/src/main/java/com/example/masterplanbbe/exam/entity/Exam.java
+++ b/src/main/java/com/example/masterplanbbe/exam/entity/Exam.java
@@ -11,7 +11,6 @@ import lombok.*;
 @Entity
 @Table(name = "exams")
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Exam extends FullAuditEntity {
     @NonNull

--- a/src/main/java/com/example/masterplanbbe/exam/entity/Exam.java
+++ b/src/main/java/com/example/masterplanbbe/exam/entity/Exam.java
@@ -6,10 +6,7 @@ import com.example.masterplanbbe.exam.enums.Category;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "exams")
@@ -37,5 +34,13 @@ public class Exam extends FullAuditEntity {
     @Column
     private Integer participantCount;
 
+    @Builder
+    public Exam(String title, Category category, String authority, Double difficulty, Integer participantCount) {
+        this.title = title;
+        this.category = category;
+        this.authority = authority;
+        this.difficulty = difficulty;
+        this.participantCount = participantCount;
+    }
 
 }

--- a/src/main/java/com/example/masterplanbbe/exam/repository/ExamBookmarkRepository.java
+++ b/src/main/java/com/example/masterplanbbe/exam/repository/ExamBookmarkRepository.java
@@ -1,0 +1,7 @@
+package com.example.masterplanbbe.exam.repository;
+
+import com.example.masterplanbbe.exam.entity.ExamBookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExamBookmarkRepository extends JpaRepository<ExamBookmark, Long> {
+}

--- a/src/main/java/com/example/masterplanbbe/exam/repository/ExamRepositoryCustom.java
+++ b/src/main/java/com/example/masterplanbbe/exam/repository/ExamRepositoryCustom.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface ExamRepositoryCustom {
-    Page<ExamItemCardDto> getExamItemCards(Pageable pageable, Long memberId);
+    Page<ExamItemCardDto> getExamItemCards(Pageable pageable, String memberId);
 }

--- a/src/main/java/com/example/masterplanbbe/exam/repository/ExamRepositoryCustom.java
+++ b/src/main/java/com/example/masterplanbbe/exam/repository/ExamRepositoryCustom.java
@@ -1,9 +1,11 @@
 package com.example.masterplanbbe.exam.repository;
 
 import com.example.masterplanbbe.exam.dto.ExamItemCardDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface ExamRepositoryCustom {
-    List<ExamItemCardDto> getExamItemCards(Long memberId);
+    Page<ExamItemCardDto> getExamItemCards(Pageable pageable, Long memberId);
 }

--- a/src/main/java/com/example/masterplanbbe/exam/repository/ExamRepositoryImpl.java
+++ b/src/main/java/com/example/masterplanbbe/exam/repository/ExamRepositoryImpl.java
@@ -25,7 +25,7 @@ public class ExamRepositoryImpl implements ExamRepositoryCustom {
 
     @Override
     public Page<ExamItemCardDto> getExamItemCards(Pageable pageable,
-                                                  Long memberId) {
+                                                  String memberId) {
         List<ExamItemCardDto> queryResult = queryFactory.select(
                         new QExamItemCardDto(
                                 exam,
@@ -33,13 +33,8 @@ public class ExamRepositoryImpl implements ExamRepositoryCustom {
                         )
                 )
                 .from(exam)
-                .leftJoin(examBookmark)
-                .on(
-                        Expressions.allOf(
-                                exam.id.eq(examBookmark.exam.id),
-                                examBookmark.member.id.eq(memberId)
-                        )
-                )
+                .leftJoin(examBookmark).fetchJoin()
+                .on(exam.id.eq(examBookmark.exam.id))
                 .orderBy(exam.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/main/java/com/example/masterplanbbe/exam/repository/ExamRepositoryImpl.java
+++ b/src/main/java/com/example/masterplanbbe/exam/repository/ExamRepositoryImpl.java
@@ -1,13 +1,59 @@
 package com.example.masterplanbbe.exam.repository;
 
 import com.example.masterplanbbe.exam.dto.ExamItemCardDto;
+import com.example.masterplanbbe.exam.dto.QExamItemCardDto;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.function.LongSupplier;
+
+import static com.example.masterplanbbe.exam.entity.QExam.exam;
+import static com.example.masterplanbbe.exam.entity.QExamBookmark.examBookmark;
 
 public class ExamRepositoryImpl implements ExamRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    public ExamRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
     @Override
-    public List<ExamItemCardDto> getExamItemCards(Long memberId) {
-        // TODO: Implement this method
-        return null;
+    public Page<ExamItemCardDto> getExamItemCards(Pageable pageable,
+                                                  Long memberId) {
+        List<ExamItemCardDto> queryResult = queryFactory.select(
+                        new QExamItemCardDto(
+                                exam,
+                                examBookmark.isNotNull()
+                        )
+                )
+                .from(exam)
+                .leftJoin(examBookmark)
+                .on(
+                        Expressions.allOf(
+                                exam.id.eq(examBookmark.exam.id),
+                                examBookmark.member.id.eq(memberId)
+                        )
+                )
+                .orderBy(exam.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        LongSupplier countQuery = () -> Optional.ofNullable(
+                queryFactory.select(
+                        exam.count()
+                )
+                .from(exam)
+                .offset(pageable.getOffset())
+                .fetchOne()
+        ).orElse(0L);
+
+        return PageableExecutionUtils.getPage(queryResult, pageable, countQuery);
     }
 }

--- a/src/main/java/com/example/masterplanbbe/exam/response/ReadAllExamResponse.java
+++ b/src/main/java/com/example/masterplanbbe/exam/response/ReadAllExamResponse.java
@@ -1,9 +1,8 @@
 package com.example.masterplanbbe.exam.response;
 
 import com.example.masterplanbbe.exam.dto.ExamItemCardDto;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
 
 public record ReadAllExamResponse(
-        List<ExamItemCardDto> examItemCardDtoSet
+        Page<ExamItemCardDto> examItemCardDtoPage
 ) {}

--- a/src/main/java/com/example/masterplanbbe/exam/service/ExamService.java
+++ b/src/main/java/com/example/masterplanbbe/exam/service/ExamService.java
@@ -1,9 +1,12 @@
 package com.example.masterplanbbe.exam.service;
 
+import com.example.masterplanbbe.exam.dto.ExamItemCardDto;
 import com.example.masterplanbbe.exam.repository.ExamRepository;
 import com.example.masterplanbbe.exam.response.ReadAllExamResponse;
 import com.example.masterplanbbe.exam.response.ReadExamResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -11,8 +14,8 @@ import org.springframework.stereotype.Service;
 public class ExamService {
     private final ExamRepository examRepository;
 
-    public ReadAllExamResponse getAllExam(Long memberId) {
-        return new ReadAllExamResponse(examRepository.getExamItemCards(memberId));
+    public Page<ExamItemCardDto> getAllExam(Pageable pageable, Long memberId) {
+        return examRepository.getExamItemCards(pageable, memberId);
     }
 
     public ReadExamResponse getExam(Long memberId) {

--- a/src/main/java/com/example/masterplanbbe/exam/service/ExamService.java
+++ b/src/main/java/com/example/masterplanbbe/exam/service/ExamService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 public class ExamService {
     private final ExamRepository examRepository;
 
-    public Page<ExamItemCardDto> getAllExam(Pageable pageable, Long memberId) {
+    public Page<ExamItemCardDto> getAllExam(Pageable pageable, String memberId) {
         return examRepository.getExamItemCards(pageable, memberId);
     }
 

--- a/src/main/java/com/example/masterplanbbe/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/masterplanbbe/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.example.masterplanbbe.member.repository;
+
+import com.example.masterplanbbe.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByUserId(String userId);
+}

--- a/src/test/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryTest.java
@@ -1,30 +1,57 @@
 package com.example.masterplanbbe.domain.exam.repository;
 
+import com.example.masterplanbbe.domain.fixture.MemberFixture;
+import com.example.masterplanbbe.exam.dto.ExamItemCardDto;
+import com.example.masterplanbbe.exam.entity.Exam;
+import com.example.masterplanbbe.exam.entity.ExamBookmark;
 import com.example.masterplanbbe.exam.repository.ExamBookmarkRepository;
 import com.example.masterplanbbe.exam.repository.ExamRepository;
 import com.example.masterplanbbe.member.entity.Member;
 import com.example.masterplanbbe.member.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
+import java.util.List;
+
+import static com.example.masterplanbbe.domain.fixture.ExamFixture.createExam;
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 public class ExamRepositoryTest {
     @Autowired private ExamRepository examRepository;
     @Autowired private MemberRepository memberRepository;
     @Autowired private ExamBookmarkRepository examBookmarkRepository;
-    private Member savedMember;
 
     @BeforeEach
     void setUp() {
-        savedMember = memberRepository.save(createMember());
+        examBookmarkRepository.deleteAll();
+        examRepository.deleteAll();
+        memberRepository.deleteAll();
     }
 
     @Test
-    void test() {
-        // test code
+    @DisplayName("사용자는 시험을 조회하고 북마크 여부를 확인할 수 있다.")
+    void retrieve_exam_and_check_bookmark_status() {
+        Member member = memberRepository.save(createMember());
+        Exam exam1 = createExam("exam1");
+        Exam exam2 = createExam("exam2");
+        examRepository.saveAll(List.of(exam1, exam2));
+        ExamBookmark examBookmark = examBookmarkRepository.save(new ExamBookmark(member, exam1));
+        PageRequest pageRequest = PageRequest.of(0, 25);
+
+        Page<ExamItemCardDto> result = examRepository.getExamItemCards(pageRequest, member.getUserId());
+
+        assertThat(result.getContent().size()).isEqualTo(2);
+        assertThat(result.getContent().get(0).title()).isEqualTo("exam2");
+        assertThat(result.getContent().get(1).title()).isEqualTo("exam1");
+        assertThat(result.getContent().get(0).isBookmarked()).isFalse();
     }
+
 }

--- a/src/test/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryTest.java
@@ -1,7 +1,15 @@
 package com.example.masterplanbbe.domain.exam.repository;
 
+import com.example.masterplanbbe.exam.repository.ExamRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 public class ExamRepositoryTest {
+    @Autowired private ExamRepository examRepository;
+
+    @BeforeEach
+    void setUp() {
+    }
 }

--- a/src/test/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryTest.java
@@ -1,15 +1,30 @@
 package com.example.masterplanbbe.domain.exam.repository;
 
+import com.example.masterplanbbe.exam.repository.ExamBookmarkRepository;
 import com.example.masterplanbbe.exam.repository.ExamRepository;
+import com.example.masterplanbbe.member.entity.Member;
+import com.example.masterplanbbe.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 
 @SpringBootTest
 public class ExamRepositoryTest {
     @Autowired private ExamRepository examRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private ExamBookmarkRepository examBookmarkRepository;
+    private Member savedMember;
 
     @BeforeEach
     void setUp() {
+        savedMember = memberRepository.save(createMember());
+    }
+
+    @Test
+    void test() {
+        // test code
     }
 }

--- a/src/test/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryTest.java
@@ -1,0 +1,7 @@
+package com.example.masterplanbbe.domain.exam.repository;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class ExamRepositoryTest {
+}

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/ExamFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/ExamFixture.java
@@ -1,0 +1,17 @@
+package com.example.masterplanbbe.domain.fixture;
+
+import com.example.masterplanbbe.exam.entity.Exam;
+
+import static com.example.masterplanbbe.exam.enums.Category.*;
+
+public class ExamFixture {
+    public static Exam createExam(String title) {
+        return Exam.builder()
+                .title(title)
+                .category(IT_ICT)
+                .authority("테스트")
+                .participantCount(100)
+                .difficulty(3.0)
+                .build();
+    }
+}

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/MemberFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/MemberFixture.java
@@ -1,0 +1,9 @@
+package com.example.masterplanbbe.domain.fixture;
+
+import com.example.masterplanbbe.member.entity.Member;
+
+public class MemberFixture {
+    public static Member createMember() {
+        return new Member("testId");
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

```java
package com.example.masterplanbbe.exam.dto;

public record ExamItemCardDto (
        String title,
        Category category,
        Double difficulty,
        Integer participants,
        Boolean isBookmarked
) {
    @QueryProjection
    public ExamItemCardDto(Exam exam, Boolean isBookmarked) {
        this(exam.getTitle(), exam.getCategory(), exam.getDifficulty(), exam.getParticipantCount(), isBookmarked);
    }
}
```

* `@QueryProjection` 어노테이션을 사용했습니다.
\
DTO에 QueryDSL 의존성이 추가되는 점은 약점이지만
projection을 수행하는 다른 방법, `Projections.constructor`에 비교해서
생성자 매개변수의 순서를 맞춰주지 않아도 된다는 장점이 있습니다.
\
이는 이후 DTO의 사양이 변경되어도 
repository 메서드가 이전처럼 기능할 가능성이 높다는 뜻입니다.[^1]

```java
package com.example.masterplanbbe.exam.repository;

public class ExamRepositoryImpl implements ExamRepositoryCustom {
    private final JPAQueryFactory queryFactory;

    public ExamRepositoryImpl(EntityManager em) {
        this.queryFactory = new JPAQueryFactory(em);
    }

    @Override
    public Page<ExamItemCardDto> getExamItemCards(Pageable pageable,
                                                  String memberId) {
        List<ExamItemCardDto> queryResult = queryFactory.select(
                        new QExamItemCardDto(
                                exam,
                                examBookmark.isNotNull()
                        )
                )
                .from(exam)
                .leftJoin(examBookmark).fetchJoin()
                .on(exam.id.eq(examBookmark.exam.id))
                .orderBy(exam.createdAt.desc())
                .offset(pageable.getOffset())
                .limit(pageable.getPageSize())
                .fetch();

        LongSupplier countQuery = () -> Optional.ofNullable(
                queryFactory.select(
                        exam.count()
                )
                .from(exam)
                .offset(pageable.getOffset())
                .fetchOne()
        ).orElse(0L);

        return PageableExecutionUtils.getPage(queryResult, pageable, countQuery);
    }
}
```

* QueryDSL을 사용한 페이지네이션 쿼리를 작성했습니다.
select 구문에서는 이전 항목에서 언급했던, `@QueryProjection` 어노테이션을 사용한
프로젝션이 이루어지고 있고,
\
이외에 특기할 만한 점은 `PageableExecutionUtils.getPage`를 이용한 
count query 최적화가 이루어지고 있다는 부분입니다.
결과값 대신 함수 객체를 전달해서 count query의 실행을 `getPage` 메서드에 위임합니다.[^2]
\
이로 인해서 
1. 전체 페이지 중 첫 번째 페이지일 때,
2. `PageRequest`의 size보다 쿼리 결과인, content의 size가 작을 때
\
페이지네이션 중, 이 두 가지 케이스에서는 count query를 실행하지 않습니다.

[^1]: [Querydsl Projection 방법 소개 및 선호하는 패턴 정리](https://cheese10yun.github.io/querydsl-projections/)
[^2]: [\[Querydsl\] Pagination 성능 개선 part1.PageableExecutionUtils](https://junior-datalist.tistory.com/342)