### PR TITLE
Feat/exam:: ExamServiceTest.getAllExam, ExamControllerTest.getAllExam 메서드 작성

### DIFF
--- a/src/main/java/com/example/masterplanbbe/common/jackson/RestPage.java
+++ b/src/main/java/com/example/masterplanbbe/common/jackson/RestPage.java
@@ -1,0 +1,4 @@
+package com.example.masterplanbbe.common.jackson;
+
+public class RestPage {
+}

--- a/src/main/java/com/example/masterplanbbe/common/jackson/RestPage.java
+++ b/src/main/java/com/example/masterplanbbe/common/jackson/RestPage.java
@@ -1,4 +1,32 @@
 package com.example.masterplanbbe.common.jackson;
 
-public class RestPage {
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"pageable"})
+public class RestPage<T> extends PageImpl<T> {
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public RestPage(@JsonProperty("content") java.util.List<T> content,
+                    @JsonProperty("number") int page,
+                    @JsonProperty("size") int size,
+                    @JsonProperty("totalElements") long totalElements) {
+
+        super(content, PageRequest.of(page, size), totalElements);
+    }
+
+    public RestPage(Page<T> page) {
+        super(page.getContent(), page.getPageable(), page.getTotalElements());
+    }
+
+    public RestPage(List<T> content, Pageable pageable, Long total) {
+        super(content, pageable, total);
+    }
 }

--- a/src/main/java/com/example/masterplanbbe/common/response/ApiResponse.java
+++ b/src/main/java/com/example/masterplanbbe/common/response/ApiResponse.java
@@ -1,9 +1,12 @@
 package com.example.masterplanbbe.common.response;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ApiResponse<T> {
     private int status;

--- a/src/main/java/com/example/masterplanbbe/exam/controller/ExamController.java
+++ b/src/main/java/com/example/masterplanbbe/exam/controller/ExamController.java
@@ -11,10 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,10 +22,10 @@ public class ExamController {
     @GetMapping
     public ResponseEntity<ApiResponse<Page<ExamItemCardDto>>> getAllExam(
             @PageableDefault Pageable pageable,
-            Member member//TODO: security context로 변경
+            @RequestParam(name = "memberId") String memberId//TODO: security context로 변경
     ) {
         return ResponseEntity.ok()
-                .body(ApiResponse.ok(examService.getAllExam(pageable, member.getUserId())));
+                .body(ApiResponse.ok(examService.getAllExam(pageable, memberId)));
     }
 
     @GetMapping("/{examId}")

--- a/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
@@ -1,0 +1,4 @@
+package com.example.masterplanbbe.domain.exam.controller;
+
+public class ExamControllerTest {
+}

--- a/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
@@ -1,4 +1,115 @@
 package com.example.masterplanbbe.domain.exam.controller;
 
+import com.example.masterplanbbe.common.jackson.RestPage;
+import com.example.masterplanbbe.common.response.ApiResponse;
+import com.example.masterplanbbe.exam.controller.ExamController;
+import com.example.masterplanbbe.exam.dto.ExamItemCardDto;
+import com.example.masterplanbbe.exam.entity.Exam;
+import com.example.masterplanbbe.exam.entity.ExamBookmark;
+import com.example.masterplanbbe.exam.service.ExamService;
+import com.example.masterplanbbe.member.entity.Member;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static com.example.masterplanbbe.domain.fixture.ExamFixture.createExam;
+import static com.example.masterplanbbe.domain.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
 public class ExamControllerTest {
+    private MockMvc mockMvc;
+
+    @Mock
+    private ExamService examService;
+
+    @InjectMocks
+    private ExamController examController;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(examController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter())
+                .build();
+    }
+
+    //TODO: mocking 중의 영향으로 Sort 가 반영돼있지 않음
+    @Test
+    @DisplayName("사용자는 시험 목록을 조회한다.")
+    void getAllExam() throws Exception {
+        Member member = createMember();
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        Page<ExamItemCardDto> mockedExamItemCardPage = createMockedExamItemCardPage(member);
+        given(examService.getAllExam(any(Pageable.class), eq(member.getUserId()))).willReturn(mockedExamItemCardPage);
+
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/exam")
+                .param("page", pageRequest.getPageNumber() + "")
+                .param("size", pageRequest.getPageSize() + "")
+                .param("sort", "createdAt,desc")
+                .param("memberId", member.getUserId())
+                .accept("application/json"));
+
+        resultActions.andExpectAll(status().isOk(), content().contentType("application/json"));
+        assertExamItemCardResponse(resultActions);
+    }
+
+    private Page<ExamItemCardDto> createMockedExamItemCardPage(Member member) {
+        Exam exam1 = createExam("exam1");
+        Exam exam2 = createExam("exam2");
+        ExamBookmark examBookmark = new ExamBookmark(member, exam1);
+        return new PageImpl<>(List.of(
+                new ExamItemCardDto(exam1, isBookmarked(examBookmark, exam1)),
+                new ExamItemCardDto(exam2, isBookmarked(examBookmark, exam2))),
+                PageRequest.of(0, 5),
+                2);
+    }
+
+    private void assertExamItemCardResponse(ResultActions resultActions) throws Exception {
+        resultActions.andDo(mvcResult -> {
+            String responseContent = mvcResult.getResponse().getContentAsString();
+            ApiResponse<RestPage<ExamItemCardDto>> result = objectMapper.readValue(responseContent, new TypeReference<ApiResponse<RestPage<ExamItemCardDto>>>() {
+            });
+            List<ExamItemCardDto> content = result.getData().getContent();
+
+            assertThat(content).hasSize(2);
+            assertAll(
+                    () -> assertThat(content.get(0).title()).isEqualTo("exam1"),
+                    () -> assertThat(content.get(0).isBookmarked()).isTrue(),
+                    () -> assertThat(content.get(1).title()).isEqualTo("exam2"),
+                    () -> assertThat(content.get(1).isBookmarked()).isFalse()
+            );
+        });
+    }
+
+    private boolean isBookmarked(ExamBookmark examBookmark,
+                                 Exam exam) {
+        return examBookmark.getExam() == exam;
+    }
 }

--- a/src/test/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.example.masterplanbbe.domain.exam.repository;
 
-import com.example.masterplanbbe.domain.fixture.MemberFixture;
 import com.example.masterplanbbe.exam.dto.ExamItemCardDto;
 import com.example.masterplanbbe.exam.entity.Exam;
 import com.example.masterplanbbe.exam.entity.ExamBookmark;
@@ -8,7 +7,6 @@ import com.example.masterplanbbe.exam.repository.ExamBookmarkRepository;
 import com.example.masterplanbbe.exam.repository.ExamRepository;
 import com.example.masterplanbbe.member.entity.Member;
 import com.example.masterplanbbe.member.repository.MemberRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,12 +20,16 @@ import java.util.List;
 import static com.example.masterplanbbe.domain.fixture.ExamFixture.createExam;
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest
 public class ExamRepositoryTest {
-    @Autowired private ExamRepository examRepository;
-    @Autowired private MemberRepository memberRepository;
-    @Autowired private ExamBookmarkRepository examBookmarkRepository;
+    @Autowired
+    private ExamRepository examRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private ExamBookmarkRepository examBookmarkRepository;
 
     @BeforeEach
     void setUp() {
@@ -48,10 +50,13 @@ public class ExamRepositoryTest {
 
         Page<ExamItemCardDto> result = examRepository.getExamItemCards(pageRequest, member.getUserId());
 
-        assertThat(result.getContent().size()).isEqualTo(2);
-        assertThat(result.getContent().get(0).title()).isEqualTo("exam2");
-        assertThat(result.getContent().get(1).title()).isEqualTo("exam1");
-        assertThat(result.getContent().get(0).isBookmarked()).isFalse();
+        assertThat(result.getContent()).hasSize(2);
+        assertAll("Exam item card details verification",
+                () -> assertThat(result.getContent().get(0).title()).isEqualTo("exam2"),
+                () -> assertThat(result.getContent().get(0).isBookmarked()).isFalse(),
+                () -> assertThat(result.getContent().get(1).title()).isEqualTo("exam1"),
+                () -> assertThat(result.getContent().get(1).isBookmarked()).isTrue()
+        );
     }
 
 }

--- a/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import static com.example.masterplanbbe.domain.fixture.ExamFixture.createExam;
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 

--- a/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
@@ -1,0 +1,4 @@
+package com.example.masterplanbbe.domain.exam.service;
+
+public class ExamServiceTest {
+}

--- a/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
@@ -1,4 +1,74 @@
 package com.example.masterplanbbe.domain.exam.service;
 
+import com.example.masterplanbbe.exam.dto.ExamItemCardDto;
+import com.example.masterplanbbe.exam.entity.Exam;
+import com.example.masterplanbbe.exam.entity.ExamBookmark;
+import com.example.masterplanbbe.exam.repository.ExamRepository;
+import com.example.masterplanbbe.exam.service.ExamService;
+import com.example.masterplanbbe.member.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.example.masterplanbbe.domain.fixture.ExamFixture.createExam;
+import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("시험 서비스 테스트")
 public class ExamServiceTest {
+    @InjectMocks
+    ExamService examService;
+    @Mock
+    ExamRepository examRepository;
+
+    @Test
+    @DisplayName("사용자는 시험을 조회하고 북마크 여부를 확인한다.")
+    void get_all_exam() {
+        Member member = createMember();
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        Page<ExamItemCardDto> mockedExamItemCardPage = createMockedExamItemCardPage(member);
+        given(examRepository.getExamItemCards(any(Pageable.class), any(String.class))).willReturn(mockedExamItemCardPage);
+
+        examService.getAllExam(pageRequest, "userId");
+
+        verify(examRepository, times(1)).getExamItemCards(any(Pageable.class), any(String.class));
+        assertExamItemCardPage(mockedExamItemCardPage);
+    }
+
+    private Page<ExamItemCardDto> createMockedExamItemCardPage(Member member) {
+        Exam exam1 = createExam("exam1");
+        Exam exam2 = createExam("exam2");
+        ExamBookmark examBookmark = new ExamBookmark(member, exam1);
+        return new PageImpl<>(List.of(
+                new ExamItemCardDto(exam1, isBookmarked(examBookmark, exam1)),
+                new ExamItemCardDto(exam2, isBookmarked(examBookmark, exam2))
+        ));
+    }
+
+    private void assertExamItemCardPage(Page<ExamItemCardDto> result) {
+        assertThat(result.getContent()).hasSize(2);
+        assertAll(
+                () -> assertThat(result.getContent().get(0).title()).isEqualTo("exam1"),
+                () -> assertThat(result.getContent().get(0).isBookmarked()).isTrue(),
+                () -> assertThat(result.getContent().get(1).title()).isEqualTo("exam2"),
+                () -> assertThat(result.getContent().get(1).isBookmarked()).isFalse()
+        );
+    }
+
+    private boolean isBookmarked(ExamBookmark examBookmark, Exam exam) {
+        return examBookmark.getExam() == exam;
+    }
 }

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/ExamTestBuilder.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/ExamTestBuilder.java
@@ -1,4 +1,0 @@
-package com.example.masterplanbbe.domain.fixture;
-
-public class ExamTestBuilder {
-}

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/ExamTestBuilder.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/ExamTestBuilder.java
@@ -1,0 +1,4 @@
+package com.example.masterplanbbe.domain.fixture;
+
+public class ExamTestBuilder {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

### ExamServiceTest.getAllExam 메서드

```java
@Test
    @DisplayName("사용자는 시험을 조회하고 북마크 여부를 확인한다.")
    void get_all_exam() {
        Member member = createMember();
        PageRequest pageRequest = PageRequest.of(0, 5);
        Page<ExamItemCardDto> mockedExamItemCardPage = createMockedExamItemCardPage(member);
        given(examRepository.getExamItemCards(any(Pageable.class), any(String.class))).willReturn(mockedExamItemCardPage);

        examService.getAllExam(pageRequest, "userId");

        verify(examRepository, times(1)).getExamItemCards(any(Pageable.class), any(String.class));
        assertExamItemCardPage(mockedExamItemCardPage);
    }
```
**설명**
* 시험 카드들을 보는, 화면 출력을 위한 서비스 메서드입니다.
repository 계층의 메서드를 호출하기만 하는 통신 역할만 하기 때문에,
반환 객체인 `mockedExamItemCardPage`를 제외하고는 
메서드 파라미터에 해당하는 변수만 선언해줬습니다.

* 반환 객체의 생성은 fixture를 이용해 만들도록 해서
현재 애플리케이션의 비즈니스 룰에 따라서 데이터베이스 일관성이 지켜지도록 했습니다.

* 검증문 또한 private 메서드로 분리돼 있는데,
객체 생성과 검증문을 test 메서드 바로 아래에 기술해 놓아서
  - 테스트를 볼 때는 통신하는 기능만 한다는 것을 알 수 있게 하고
  - 반환 객체와 그 검증은 필요에 따라 찾아볼 수 있게 했습니다.

### ExamControllerTest.getAllExam 메서드

```java
@Test
    @DisplayName("사용자는 시험 목록을 조회한다.")
    void getAllExam() throws Exception {
        Member member = createMember();
        PageRequest pageRequest = PageRequest.of(0, 5);
        Page<ExamItemCardDto> mockedExamItemCardPage = createMockedExamItemCardPage(member);
        given(examService.getAllExam(any(Pageable.class), eq(member.getUserId()))).willReturn(mockedExamItemCardPage);

        ResultActions resultActions = mockMvc.perform(get("/api/v1/exam")
                .param("page", pageRequest.getPageNumber() + "")
                .param("size", pageRequest.getPageSize() + "")
                .param("sort", "createdAt,desc")
                .param("memberId", member.getUserId())
                .accept("application/json"));

        resultActions.andExpectAll(status().isOk(), content().contentType("application/json"));
        assertExamItemCardResponse(resultActions);
    }
```
**설명**
* 역시 통신 기능에만 집중할 수 있게 메서드 바디에는 가능한 축약된 내용만 적었습니다.

```java
private void assertExamItemCardResponse(ResultActions resultActions) throws Exception {
        resultActions.andDo(mvcResult -> {
            String responseContent = mvcResult.getResponse().getContentAsString();
            ApiResponse<RestPage<ExamItemCardDto>> result = objectMapper.readValue(responseContent, new TypeReference<ApiResponse<RestPage<ExamItemCardDto>>>() {
            });
            List<ExamItemCardDto> content = result.getData().getContent();

            assertThat(content).hasSize(2);
            assertAll(
                    () -> assertThat(content.get(0).title()).isEqualTo("exam1"),
                    () -> assertThat(content.get(0).isBookmarked()).isTrue(),
                    () -> assertThat(content.get(1).title()).isEqualTo("exam2"),
                    () -> assertThat(content.get(1).isBookmarked()).isFalse()
            );
        });
    }
```

* 위 코드는 검증문인데요. 반환 객체를 역직렬화한 후, 
assertAll을 통해서 상태를 일괄로 검사할 수 있게 했습니다.

- - -
참고한 자료: 
[Spring | Redis로 Page 캐시 처리하기](https://velog.io/@llocr/Spring-Redis%EB%A1%9C-Page-%EC%BA%90%EC%8B%9C-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0)
[ObjectMapper 불변 객체 직렬화/역직렬화](https://velog.io/@biddan606/Java-ObjectMapper-%EC%A7%81%EB%A0%AC%ED%99%94%EC%97%AD%EC%A7%81%EB%A0%AC%ED%99%94)
