### PR TITLE
Feat/adapt port

### DIFF
--- a/src/main/java/com/example/masterplanbbe/common/config/QuerydslConfig.java
+++ b/src/main/java/com/example/masterplanbbe/common/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.example.masterplanbbe.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    private final EntityManager em;
+
+    public QuerydslConfig(EntityManager em) {
+        this.em = em;
+    }
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/example/masterplanbbe/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/masterplanbbe/common/exception/ErrorCode.java
@@ -26,6 +26,9 @@ public enum ErrorCode {
     SOCIAL_EMAIL_LOAD_FAIL(400, "O001", "소셜 로그인에서 이메일을 불러올 수 없습니다."),
     SOCIAL_NAME_LOAD_FAIL(400, "O002", "소셜 로그인에서 이름을 불러올 수 없습니다."),
 
+    // Exam
+    EXAM_NOT_FOUND(404, "E001", "시험을 찾을 수 없습니다."),
+
     // Post
     INVALID_INPUT_TITLE(400,"P001","유효하지 않은 타이틀입니다."),
     INVALID_INPUT_CONTENT(400,"P002","유효하지 않은 내용입니다."),

--- a/src/main/java/com/example/masterplanbbe/domain/exam/repository/ExamRepository.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/repository/ExamRepository.java
@@ -3,5 +3,5 @@ package com.example.masterplanbbe.domain.exam.repository;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ExamRepository extends JpaRepository<Exam, Long>, ExamRepositoryCustom {
+public interface ExamRepository extends JpaRepository<Exam, Long> {
 }

--- a/src/main/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryAdapter.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryAdapter.java
@@ -2,26 +2,31 @@ package com.example.masterplanbbe.domain.exam.repository;
 
 import com.example.masterplanbbe.domain.exam.dto.ExamItemCardDto;
 import com.example.masterplanbbe.domain.exam.dto.QExamItemCardDto;
+import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.function.LongSupplier;
 
+import static com.example.masterplanbbe.common.GlobalException.*;
+import static com.example.masterplanbbe.common.exception.ErrorCode.*;
 import static com.example.masterplanbbe.domain.exam.entity.QExam.exam;
 import static com.example.masterplanbbe.domain.exam.entity.QExamBookmark.examBookmark;
 
 
-public class ExamRepositoryImpl implements ExamRepositoryCustom {
+@Repository
+@RequiredArgsConstructor
+public class ExamRepositoryAdapter implements ExamRepositoryPort, ExamRepositoryCustom {
+    private final ExamRepository examRepository;
     private final JPAQueryFactory queryFactory;
-
-    public ExamRepositoryImpl(EntityManager em) {
-        this.queryFactory = new JPAQueryFactory(em);
-    }
 
     @Override
     public Page<ExamItemCardDto> getExamItemCards(Pageable pageable,
@@ -50,5 +55,25 @@ public class ExamRepositoryImpl implements ExamRepositoryCustom {
         ).orElse(0L);
 
         return PageableExecutionUtils.getPage(queryResult, pageable, countQuery);
+    }
+
+    @Override
+    public Exam getById(Long examId) {
+        return examRepository.findById(examId).orElseThrow(() -> new NotFoundException(EXAM_NOT_FOUND));
+    }
+
+    @Override
+    public Exam save(Exam exam) {
+        return examRepository.save(exam);
+    }
+
+    @Override
+    public void saveAll(Iterable<Exam> exams) {
+        examRepository.saveAll(exams);
+    }
+
+    @Override
+    public void deleteAll() {
+        examRepository.deleteAll();
     }
 }

--- a/src/main/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryPort.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryPort.java
@@ -1,0 +1,13 @@
+package com.example.masterplanbbe.domain.exam.repository;
+
+import com.example.masterplanbbe.domain.exam.entity.Exam;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ExamRepositoryPort extends ExamRepositoryCustom {
+    Exam getById(Long examId);
+    Exam save(Exam exam);
+    void saveAll(Iterable<Exam> exams);
+    void deleteAll();
+}

--- a/src/main/java/com/example/masterplanbbe/domain/exam/service/ExamService.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/service/ExamService.java
@@ -1,7 +1,7 @@
 package com.example.masterplanbbe.domain.exam.service;
 
 import com.example.masterplanbbe.domain.exam.dto.ExamItemCardDto;
-import com.example.masterplanbbe.domain.exam.repository.ExamRepository;
+import com.example.masterplanbbe.domain.exam.repository.ExamRepositoryPort;
 import com.example.masterplanbbe.domain.exam.response.ReadExamResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -11,10 +11,10 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class ExamService {
-    private final ExamRepository examRepository;
+    private final ExamRepositoryPort examRepositoryPort;
 
     public Page<ExamItemCardDto> getAllExam(Pageable pageable, String memberId) {
-        return examRepository.getExamItemCards(pageable, memberId);
+        return examRepositoryPort.getExamItemCards(pageable, memberId);
     }
 
     public ReadExamResponse getExam(Long memberId) {

--- a/src/test/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryPortTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryPortTest.java
@@ -20,15 +20,15 @@ import static com.example.masterplanbbe.domain.fixture.MemberFixture.createMembe
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-public class ExamRepositoryTest {
-    @Autowired private ExamRepository examRepository;
+public class ExamRepositoryPortTest {
+    @Autowired private ExamRepositoryPort examRepositoryPort;
     @Autowired private MemberRepository memberRepository;
     @Autowired private ExamBookmarkRepository examBookmarkRepository;
 
     @BeforeEach
     void setUp() {
         examBookmarkRepository.deleteAll();
-        examRepository.deleteAll();
+        examRepositoryPort.deleteAll();
         memberRepository.deleteAll();
     }
 
@@ -38,11 +38,11 @@ public class ExamRepositoryTest {
         Member member = memberRepository.save(createMember());
         Exam exam1 = createExam("exam1");
         Exam exam2 = createExam("exam2");
-        examRepository.saveAll(List.of(exam1, exam2));
+        examRepositoryPort.saveAll(List.of(exam1, exam2));
         ExamBookmark examBookmark = examBookmarkRepository.save(new ExamBookmark(member, exam1));
         PageRequest pageRequest = PageRequest.of(0, 25);
 
-        Page<ExamItemCardDto> result = examRepository.getExamItemCards(pageRequest, member.getUserId());
+        Page<ExamItemCardDto> result = examRepositoryPort.getExamItemCards(pageRequest, member.getUserId());
 
         assertThat(result.getContent().size()).isEqualTo(2);
         assertThat(result.getContent().get(0).title()).isEqualTo("exam2");

--- a/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
@@ -3,7 +3,7 @@ package com.example.masterplanbbe.domain.exam.service;
 import com.example.masterplanbbe.domain.exam.dto.ExamItemCardDto;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.entity.ExamBookmark;
-import com.example.masterplanbbe.domain.exam.repository.ExamRepository;
+import com.example.masterplanbbe.domain.exam.repository.ExamRepositoryPort;
 import com.example.masterplanbbe.member.entity.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,7 +30,7 @@ public class ExamServiceTest {
     @InjectMocks
     ExamService examService;
     @Mock
-    ExamRepository examRepository;
+    ExamRepositoryPort examRepositoryPort;
 
     @Test
     @DisplayName("사용자는 시험을 조회하고 북마크 여부를 확인한다.")
@@ -38,11 +38,11 @@ public class ExamServiceTest {
         Member member = createMember();
         PageRequest pageRequest = PageRequest.of(0, 5);
         Page<ExamItemCardDto> mockedExamItemCardPage = createMockedExamItemCardPage(member);
-        given(examRepository.getExamItemCards(any(Pageable.class), any(String.class))).willReturn(mockedExamItemCardPage);
+        given(examRepositoryPort.getExamItemCards(any(Pageable.class), any(String.class))).willReturn(mockedExamItemCardPage);
 
         examService.getAllExam(pageRequest, "userId");
 
-        verify(examRepository, times(1)).getExamItemCards(any(Pageable.class), any(String.class));
+        verify(examRepositoryPort, times(1)).getExamItemCards(any(Pageable.class), any(String.class));
         assertExamItemCardPage(mockedExamItemCardPage);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

* 리포지토리 계층에 어댑터 포트 패턴을 반영했습니다. 
\
효선 님께서 적용하신 것을 보고 참고해 반영했는데요.
NotFoundException을 repository 계층에서 검사하기 때문에
테스트 대상이 repository 계층으로 이동한 결과,
\
서비스 계층에서 객체를 사용하는 메서드마다
이를 분기 처리해서 테스트하지 않아도 되는 장점이 있다고 파악했습니다.
\
그래서 JpaRepository 메서드를 재호출하도록
Adapter 쪽에 작성하는 비용이 있긴 하지만
충분한 이점이 되는 거 같습니다.

* Adapter 는 QueryDsl 코드도 같이 구현하고 있는데요.

```java
package com.example.masterplanbbe.common.config;

@Configuration
public class QuerydslConfig {
    private final EntityManager em;

    public QuerydslConfig(EntityManager em) {
        this.em = em;
    }

    @Bean
    public JPAQueryFactory jpaQueryFactory() {
        return new JPAQueryFactory(em);
    }
}
```

Configuration 클래스를 작성하니 정상적으로 
JPAQueryFactory를 주입할 수 있었습니다.