### PR TITLE
Feat/exam:: 리포지토리 메서드 추가, 컨트롤러 메서드에 print 구문 추가

### DIFF
--- a/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
@@ -36,6 +36,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -75,7 +76,8 @@ public class ExamControllerTest {
                 .param("memberId", member.getUserId())
                 .accept("application/json"));
 
-        resultActions.andExpectAll(status().isOk(), content().contentType("application/json"));
+        resultActions.andExpectAll(status().isOk(), content().contentType("application/json"))
+                .andDo(print());
         assertExamItemCardResponse(resultActions);
     }
 

--- a/src/test/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryPortTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/repository/ExamRepositoryPortTest.java
@@ -1,5 +1,7 @@
 package com.example.masterplanbbe.domain.exam.repository;
 
+import com.example.masterplanbbe.common.GlobalException;
+import com.example.masterplanbbe.common.exception.ErrorCode;
 import com.example.masterplanbbe.domain.exam.dto.ExamItemCardDto;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.entity.ExamBookmark;
@@ -15,9 +17,11 @@ import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
+import static com.example.masterplanbbe.common.exception.ErrorCode.*;
 import static com.example.masterplanbbe.domain.fixture.ExamFixture.createExam;
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @SpringBootTest
 public class ExamRepositoryPortTest {
@@ -48,6 +52,18 @@ public class ExamRepositoryPortTest {
         assertThat(result.getContent().get(0).title()).isEqualTo("exam2");
         assertThat(result.getContent().get(1).title()).isEqualTo("exam1");
         assertThat(result.getContent().get(0).isBookmarked()).isFalse();
+    }
+
+    @Test
+    @DisplayName("요청한 id의 시험이 없으면 예외를 발생시킨다.")
+    void throw_exception_when_exam_not_found() {
+        Exam exam = createExam("exam");
+
+        examRepositoryPort.save(exam);
+
+        assertThatThrownBy(() -> examRepositoryPort.getById(-1L))
+                .isInstanceOf(GlobalException.NotFoundException.class)
+                .hasMessageContaining(EXAM_NOT_FOUND.getMessage());
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

###  `ExamRepositoryPort.getById(Long examId)` 메서드에 대한 테스트를 추가했습니다.

```java
package com.example.masterplanbbe.domain.exam.repository;

@Test
    @DisplayName("요청한 id의 시험이 없으면 예외를 발생시킨다.")
    void throw_exception_when_exam_not_found() {
        Exam exam = createExam("exam");

        examRepositoryPort.save(exam);

        assertThatThrownBy(() -> examRepositoryPort.getById(-1L))
                .isInstanceOf(GlobalException.NotFoundException.class)
                .hasMessageContaining(EXAM_NOT_FOUND.getMessage());
    }
```
* 기본 auto increment 정책과 다르게 -1L로 값을 주어
반드시 없는 id가 되도록 했고

* `ErrorCode.getMessage()`로 메시지 내용을 검사해서
이후 메시지 내용이 바뀌더라도 테스트가 깨지지 않게 했습니다.

### 컨트롤러 메서드에 print 구문을 추가했습니다.
```java
package com.example.masterplanbbe.domain.exam.controller;

    //TODO: mocking 중의 영향으로 Sort 가 반영돼있지 않음
    @Test
    @DisplayName("사용자는 시험 목록을 조회한다.")
    void getAllExam() throws Exception {
        Member member = createMember();
        PageRequest pageRequest = PageRequest.of(0, 5);
        Page<ExamItemCardDto> mockedExamItemCardPage = createMockedExamItemCardPage(member);
        given(examService.getAllExam(any(Pageable.class), eq(member.getUserId()))).willReturn(mockedExamItemCardPage);
        ResultActions resultActions = mockMvc.perform(get("/api/v1/exam")
                .param("page", pageRequest.getPageNumber() + "")
                .param("size", pageRequest.getPageSize() + "")
                .param("sort", "createdAt,desc")
                .param("memberId", member.getUserId())
                .accept("application/json"));

        resultActions.andExpectAll(status().isOk(), content().contentType("application/json"))
                .andDo(print());
        assertExamItemCardResponse(resultActions);
    }
```

이 조치로 프론트분들과 협력할 때 용이할 거 같아 추가하게 되었습니다.

![image](https://github.com/user-attachments/assets/09503410-77fe-4b16-84a9-f496613a23b0)

사진처럼 `Show as JSON` 을 누르면,

```json
{
  "status": 200,
  "message": "OK",
  "data": {
    "content": [
      {
        "title": "exam1",
        "category": "IT_ICT",
        "difficulty": 3.0,
        "participants": 100,
        "isBookmarked": true
      },
      {
        "title": "exam2",
        "category": "IT_ICT",
        "difficulty": 3.0,
        "participants": 100,
        "isBookmarked": false
      }
    ],
    "pageable": {
      "pageNumber": 0,
      "pageSize": 5,
      "sort": {
        "empty": true,
        "sorted": false,
        "unsorted": true
      },
      "offset": 0,
      "paged": true,
      "unpaged": false
    },
    "totalElements": 2,
    "last": true,
    "totalPages": 1,
    "size": 5,
    "number": 0,
    "sort": {
      "empty": true,
      "sorted": false,
      "unsorted": true
    },
    "first": true,
    "numberOfElements": 2,
    "empty": false
  }
}
```
IDEA상에서 새 탭에 JSON 내용이 출력됩니다.