### PR TITLE
Feat/exam:: ExamService.create 메서드에 테스트 작성

### DIFF
--- a/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
@@ -4,25 +4,32 @@ import com.example.masterplanbbe.domain.exam.dto.ExamItemCardDto;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.entity.ExamBookmark;
 import com.example.masterplanbbe.domain.exam.repository.ExamRepositoryPort;
+import com.example.masterplanbbe.domain.exam.request.ExamCreateRequest;
+import com.example.masterplanbbe.domain.exam.response.CreateExamResponse;
 import com.example.masterplanbbe.member.entity.Member;
+import com.example.masterplanbbe.utils.TestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 
 import static com.example.masterplanbbe.domain.fixture.ExamFixture.createExam;
+import static com.example.masterplanbbe.domain.fixture.ExamFixture.createExamCreateRequest;
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("시험 서비스 테스트")
@@ -37,13 +44,13 @@ public class ExamServiceTest {
     void get_all_exam() {
         Member member = createMember();
         PageRequest pageRequest = PageRequest.of(0, 5);
-        Page<ExamItemCardDto> mockedExamItemCardPage = createMockedExamItemCardPage(member);
-        given(examRepositoryPort.getExamItemCards(any(Pageable.class), any(String.class))).willReturn(mockedExamItemCardPage);
+        Page<ExamItemCardDto> mocked = createMockedExamItemCardPage(member);
+        given(examRepositoryPort.getExamItemCards(any(Pageable.class), any(String.class))).willReturn(mocked);
 
         examService.getAllExam(pageRequest, "userId");
 
         verify(examRepositoryPort, times(1)).getExamItemCards(any(Pageable.class), any(String.class));
-        assertExamItemCardPage(mockedExamItemCardPage);
+        assertExamItemCardPage(mocked);
     }
 
     private Page<ExamItemCardDto> createMockedExamItemCardPage(Member member) {
@@ -66,7 +73,33 @@ public class ExamServiceTest {
         );
     }
 
-    private boolean isBookmarked(ExamBookmark examBookmark, Exam exam) {
+    private boolean isBookmarked(ExamBookmark examBookmark,
+                                 Exam exam) {
         return examBookmark.getExam() == exam;
+    }
+
+    @Test
+    @DisplayName("관리자는 시험을 추가한다.")
+    void add_exam() {
+        ExamCreateRequest request = createExamCreateRequest("exam1");
+        given(examRepositoryPort.save(any(Exam.class))).willAnswer(this::simulateSavingExamWithId);
+
+        CreateExamResponse result = examService.create(request);
+
+        verify(examRepositoryPort, times(1)).save(any(Exam.class));
+        assertAll(
+                () -> assertThat(result.examId()).isNotNull(),
+                () -> assertThat(result.title()).isEqualTo("exam1"),
+                () -> assertThat(result.category()).isEqualTo(request.category()),
+                () -> assertThat(result.authority()).isEqualTo(request.authority()),
+                () -> assertThat(result.subjects()).isEqualTo(request.subjects())
+        );
+    }
+
+    private Exam simulateSavingExamWithId(InvocationOnMock invocation) {
+        return TestUtils.withSetup(
+                () -> invocation.getArgument(0),
+                exam -> setField(exam, "id", 1L)
+        );
     }
 }

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/ExamFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/ExamFixture.java
@@ -1,8 +1,13 @@
 package com.example.masterplanbbe.domain.fixture;
 
 import com.example.masterplanbbe.domain.exam.entity.Exam;
+import com.example.masterplanbbe.domain.exam.enums.CertificationType;
+import com.example.masterplanbbe.domain.exam.request.ExamCreateRequest;
+
+import java.util.List;
 
 import static com.example.masterplanbbe.domain.exam.enums.Category.IT_ICT;
+import static com.example.masterplanbbe.domain.exam.enums.CertificationType.*;
 
 public class ExamFixture {
     public static Exam createExam(String title) {
@@ -13,5 +18,9 @@ public class ExamFixture {
                 .participantCount(100)
                 .difficulty(3.0)
                 .build();
+    }
+
+    public static ExamCreateRequest createExamCreateRequest(String title) {
+        return new ExamCreateRequest(title, IT_ICT, "테스트", NATIONAL_CERTIFIED, List.of());
     }
 }

--- a/src/test/java/com/example/masterplanbbe/utils/TestUtils.java
+++ b/src/test/java/com/example/masterplanbbe/utils/TestUtils.java
@@ -1,0 +1,12 @@
+package com.example.masterplanbbe.utils;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class TestUtils {
+    public static <T> T withSetup(Supplier<T> supplier, Consumer<T> setup) {
+        T instance = supplier.get();
+        setup.accept(instance);
+        return instance;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

```java
@Test
    @DisplayName("관리자는 시험을 추가한다.")
    void add_exam() {
        ExamCreateRequest request = createExamCreateRequest("exam1");
        given(examRepositoryPort.save(any(Exam.class))).willAnswer(this::simulateSavingExamWithId);

        CreateExamResponse result = examService.create(request);

        verify(examRepositoryPort, times(1)).save(any(Exam.class));
        assertAll(
                () -> assertThat(result.examId()).isNotNull(),
                () -> assertThat(result.title()).isEqualTo("exam1"),
                () -> assertThat(result.category()).isEqualTo(request.category()),
                () -> assertThat(result.authority()).isEqualTo(request.authority()),
                () -> assertThat(result.subjects()).isEqualTo(request.subjects())
        );
    }
```

객체의 영속화가 이루어지면
null이던 id 필드가 초기화되는데
영속화 과정을 mocking하며 표현해봤습니다.

* 반환 시에 mocking 중인 메서드 정보를 가공할 수 있는
`BDDMockito.given(T methodCall).willAnswer(Answer<T>)` 메서드와

* 리플렉션을 이용해 값을 set하는 `ReflectionTestUtils.setField` 메서드,

* 그리고 객체의 변환 생성을 나타내는 `TestUtils.withSetup` 메서드로
이를 구현했습니다.