### PR TITLE
Feat/exam:: 시험 수정 메서드 추가 및 역직렬화 오류 해결

### DIFF
--- a/src/main/java/com/example/masterplanbbe/domain/exam/controller/ExamController.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/controller/ExamController.java
@@ -3,8 +3,10 @@ package com.example.masterplanbbe.domain.exam.controller;
 import com.example.masterplanbbe.common.response.ApiResponse;
 import com.example.masterplanbbe.domain.exam.dto.ExamItemCardDto;
 import com.example.masterplanbbe.domain.exam.request.ExamCreateRequest;
+import com.example.masterplanbbe.domain.exam.request.ExamUpdateRequest;
 import com.example.masterplanbbe.domain.exam.response.CreateExamResponse;
 import com.example.masterplanbbe.domain.exam.response.ReadExamResponse;
+import com.example.masterplanbbe.domain.exam.response.UpdateExamResponse;
 import com.example.masterplanbbe.domain.exam.service.ExamService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -48,6 +50,16 @@ public class ExamController {
     ) {
         return ResponseEntity.ok()
                 .body(ApiResponse.ok(examService.create(request)));
+    }
+
+    @Operation(summary = "시험 수정")
+    @PatchMapping("/{examId}")
+    public ResponseEntity<ApiResponse<UpdateExamResponse>> update(
+            @PathVariable("examId") Long examId,
+            @RequestBody ExamUpdateRequest request
+    ) {
+        return ResponseEntity.ok()
+                .body(ApiResponse.ok(examService.update(examId, request)));
     }
 
     @Operation(summary = "시험 삭제")

--- a/src/main/java/com/example/masterplanbbe/domain/exam/dto/SubjectDto.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/dto/SubjectDto.java
@@ -1,0 +1,23 @@
+package com.example.masterplanbbe.domain.exam.dto;
+
+import com.example.masterplanbbe.common.annotation.Nullable;
+import com.example.masterplanbbe.domain.exam.entity.Subject;
+
+public record SubjectDto(
+        @Nullable
+        Long id,
+        Long examId,
+        String title,
+        String description
+) {
+    public SubjectDto(Subject subject) {
+        this(subject.getId(), subject.getExam().getId(), subject.getTitle(), subject.getDescription());
+    }
+
+    public Subject toEntity() {
+        return Subject.builder()
+                .title(title)
+                .description(description)
+                .build();
+    }
+}

--- a/src/main/java/com/example/masterplanbbe/domain/exam/entity/Exam.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/entity/Exam.java
@@ -3,8 +3,10 @@ package com.example.masterplanbbe.domain.exam.entity;
 import com.example.masterplanbbe.common.annotation.NonNull;
 import com.example.masterplanbbe.common.annotation.Nullable;
 import com.example.masterplanbbe.common.domain.FullAuditEntity;
+import com.example.masterplanbbe.domain.exam.dto.SubjectDto;
 import com.example.masterplanbbe.domain.exam.enums.Category;
 import com.example.masterplanbbe.domain.exam.enums.CertificationType;
+import com.example.masterplanbbe.domain.exam.request.ExamUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
@@ -12,6 +14,9 @@ import jakarta.persistence.Table;
 import lombok.*;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Entity
 @Table(name = "exams")
@@ -28,7 +33,7 @@ public class Exam extends FullAuditEntity {
 
     @NonNull
     @Column
-    private String authority ;
+    private String authority;
 
     @NonNull
     @Column
@@ -44,17 +49,49 @@ public class Exam extends FullAuditEntity {
 
     @Nullable
     @OneToMany(mappedBy = "exam")
-    private List<Subject> subjects;
+    private List<Subject> subjects = List.of();
 
     @Builder
-    public Exam(String title, Category category, String authority, Double difficulty, Integer participantCount, CertificationType certificationType, List<Subject> subjects) {
+    public Exam(String title,
+                Category category,
+                String authority,
+                Double difficulty,
+                Integer participantCount,
+                CertificationType certificationType,
+                List<Subject> subjects) {
         this.title = title;
         this.category = category;
         this.authority = authority;
         this.difficulty = difficulty;
         this.participantCount = participantCount;
         this.certificationType = certificationType;
-        this.subjects = subjects;
+        this.subjects = subjects != null ? subjects : List.of();
     }
 
+    public void update(ExamUpdateRequest request) {
+        this.title = request.title();
+        this.category = request.category();
+        this.authority = request.authority();
+        this.difficulty = request.difficulty();
+        this.participantCount = request.participantCount();
+        this.certificationType = request.certificationType();
+        this.subjects = getUpdatedSubjects(request.subjects());
+    }
+
+    private List<Subject> getUpdatedSubjects(List<SubjectDto> subjectDtos) {
+        Map<Long, Subject> subjectMap = this.subjects != null ?
+                this.subjects.stream().collect(Collectors.toMap(Subject::getId, Function.identity())) :
+                Map.of();
+
+        return subjectDtos.stream()
+                .map(subjectDto -> {
+                    Subject subject = subjectMap.get(subjectDto.id());
+                    if (subject == null) {
+                        return new Subject(this, subjectDto.title(), subjectDto.description());
+                    }
+                    subject.update(subjectDto.title(), subjectDto.description());
+                    return subject;
+                })
+                .toList();
+    }
 }

--- a/src/main/java/com/example/masterplanbbe/domain/exam/entity/Subject.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/entity/Subject.java
@@ -3,15 +3,11 @@ package com.example.masterplanbbe.domain.exam.entity;
 import com.example.masterplanbbe.common.annotation.NonNull;
 import com.example.masterplanbbe.common.domain.FullAuditEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "subjects")
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Subject extends FullAuditEntity {
     @NonNull
@@ -26,4 +22,16 @@ public class Subject extends FullAuditEntity {
     @NonNull
     @Column
     private String description;
+
+    @Builder
+    public Subject(Exam exam, String title, String description) {
+        this.exam = exam;
+        this.title = title;
+        this.description = description;
+    }
+
+    public void update(String title, String description) {
+        this.title = title;
+        this.description = description;
+    }
 }

--- a/src/main/java/com/example/masterplanbbe/domain/exam/request/ExamCreateRequest.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/request/ExamCreateRequest.java
@@ -1,5 +1,6 @@
 package com.example.masterplanbbe.domain.exam.request;
 
+import com.example.masterplanbbe.domain.exam.dto.SubjectDto;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.entity.Subject;
 import com.example.masterplanbbe.domain.exam.enums.Category;
@@ -12,7 +13,7 @@ public record ExamCreateRequest(
         Category category,
         String authority,
         CertificationType certificationType,
-        List<Subject> subjects
+        List<SubjectDto> subjectDtoList
 ) {
     public Exam toEntity() {
         return new Exam(
@@ -22,7 +23,9 @@ public record ExamCreateRequest(
                 0.0,
                 0,
                 certificationType,
-                subjects
+                subjectDtoList != null ?
+                        subjectDtoList.stream().map(SubjectDto::toEntity).toList() :
+                        List.of()
         );
     }
 }

--- a/src/main/java/com/example/masterplanbbe/domain/exam/request/ExamUpdateRequest.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/request/ExamUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.example.masterplanbbe.domain.exam.request;
+
+public record ExamUpdateRequest() {
+}

--- a/src/main/java/com/example/masterplanbbe/domain/exam/request/ExamUpdateRequest.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/request/ExamUpdateRequest.java
@@ -1,4 +1,18 @@
 package com.example.masterplanbbe.domain.exam.request;
 
-public record ExamUpdateRequest() {
+import com.example.masterplanbbe.domain.exam.dto.SubjectDto;
+import com.example.masterplanbbe.domain.exam.enums.Category;
+import com.example.masterplanbbe.domain.exam.enums.CertificationType;
+
+import java.util.List;
+
+public record ExamUpdateRequest(
+        String title,
+        Category category,
+        String authority,
+        Double difficulty,
+        Integer participantCount,
+        CertificationType certificationType,
+        List<SubjectDto> subjects
+) {
 }

--- a/src/main/java/com/example/masterplanbbe/domain/exam/response/CreateExamResponse.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/response/CreateExamResponse.java
@@ -1,19 +1,28 @@
 package com.example.masterplanbbe.domain.exam.response;
 
+import com.example.masterplanbbe.domain.exam.dto.SubjectDto;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
-import com.example.masterplanbbe.domain.exam.entity.Subject;
 import com.example.masterplanbbe.domain.exam.enums.Category;
 
 import java.util.List;
+import java.util.Objects;
 
 public record CreateExamResponse(
         Long examId,
         String title,
         Category category,
         String authority,
-        List<Subject> subjects
+        List<SubjectDto> subjectDtoList
 ) {
     public CreateExamResponse(Exam exam){
-        this(exam.getId(), exam.getTitle(), exam.getCategory(), exam.getAuthority(), exam.getSubjects());
+        this(
+                exam.getId(),
+                exam.getTitle(),
+                exam.getCategory(),
+                exam.getAuthority(),
+                Objects.requireNonNull(exam.getSubjects()).stream()
+                        .map(SubjectDto::new)
+                        .toList()
+        );
     }
 }

--- a/src/main/java/com/example/masterplanbbe/domain/exam/response/UpdateExamResponse.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/response/UpdateExamResponse.java
@@ -1,4 +1,35 @@
 package com.example.masterplanbbe.domain.exam.response;
 
-public record UpdateExamResponse() {
+import com.example.masterplanbbe.domain.exam.dto.SubjectDto;
+import com.example.masterplanbbe.domain.exam.entity.Exam;
+import com.example.masterplanbbe.domain.exam.entity.Subject;
+import com.example.masterplanbbe.domain.exam.enums.Category;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public record UpdateExamResponse(
+        Long examId,
+        String title,
+        Category category,
+        String authority,
+        Double difficulty,
+        Integer participantCount,
+        List<SubjectDto> subjects
+) {
+    public UpdateExamResponse(Exam exam) {
+        this(
+                exam.getId(),
+                exam.getTitle(),
+                exam.getCategory(),
+                exam.getAuthority(),
+                exam.getDifficulty(),
+                exam.getParticipantCount(),
+                Objects.requireNonNull(exam.getSubjects())
+                        .stream()
+                        .map(SubjectDto::new)
+                        .toList()
+        );
+    }
 }

--- a/src/main/java/com/example/masterplanbbe/domain/exam/response/UpdateExamResponse.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/response/UpdateExamResponse.java
@@ -1,0 +1,4 @@
+package com.example.masterplanbbe.domain.exam.response;
+
+public record UpdateExamResponse() {
+}

--- a/src/main/java/com/example/masterplanbbe/domain/exam/service/ExamService.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/service/ExamService.java
@@ -1,10 +1,14 @@
 package com.example.masterplanbbe.domain.exam.service;
 
 import com.example.masterplanbbe.domain.exam.dto.ExamItemCardDto;
+import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.repository.ExamRepositoryPort;
 import com.example.masterplanbbe.domain.exam.request.ExamCreateRequest;
+import com.example.masterplanbbe.domain.exam.request.ExamUpdateRequest;
 import com.example.masterplanbbe.domain.exam.response.CreateExamResponse;
 import com.example.masterplanbbe.domain.exam.response.ReadExamResponse;
+import com.example.masterplanbbe.domain.exam.response.UpdateExamResponse;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,7 +19,8 @@ import org.springframework.stereotype.Service;
 public class ExamService {
     private final ExamRepositoryPort examRepositoryPort;
 
-    public Page<ExamItemCardDto> getAllExam(Pageable pageable, String memberId) {
+    public Page<ExamItemCardDto> getAllExam(Pageable pageable,
+                                            String memberId) {
         return examRepositoryPort.getExamItemCards(pageable, memberId);
     }
 
@@ -30,5 +35,13 @@ public class ExamService {
 
     public void delete(Long examId) {
         examRepositoryPort.deleteById(examId);
+    }
+
+    @Transactional
+    public UpdateExamResponse update(Long examId,
+                                     ExamUpdateRequest request) {
+        Exam exam = examRepositoryPort.getById(examId);
+        exam.update(request);
+        return new UpdateExamResponse(exam);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

* 시험 수정 메서드를 추가했습니다.
* 역직렬화 오류를 해결했습니다.
`@JsonCreater` 없이 객체를 그대로 반환하는 실수를
DTO를 추가함으로써 고쳤습니다.