### PR TITLE
Feat/exam:: 시험 수정 메서드의 엔티티, 서비스, 컨트롤러 테스트 작성

### DIFF
--- a/src/main/java/com/example/masterplanbbe/domain/exam/entity/Exam.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/entity/Exam.java
@@ -82,6 +82,9 @@ public class Exam extends FullAuditEntity {
         Map<Long, Subject> subjectMap = this.subjects != null ?
                 this.subjects.stream().collect(Collectors.toMap(Subject::getId, Function.identity())) :
                 Map.of();
+        if (subjectDtos == null) {
+            return List.of();
+        }
 
         return subjectDtos.stream()
                 .map(subjectDto -> {

--- a/src/main/java/com/example/masterplanbbe/domain/exam/request/ExamCreateRequest.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/request/ExamCreateRequest.java
@@ -2,7 +2,6 @@ package com.example.masterplanbbe.domain.exam.request;
 
 import com.example.masterplanbbe.domain.exam.dto.SubjectDto;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
-import com.example.masterplanbbe.domain.exam.entity.Subject;
 import com.example.masterplanbbe.domain.exam.enums.Category;
 import com.example.masterplanbbe.domain.exam.enums.CertificationType;
 
@@ -13,7 +12,7 @@ public record ExamCreateRequest(
         Category category,
         String authority,
         CertificationType certificationType,
-        List<SubjectDto> subjectDtoList
+        List<SubjectDto> subjects
 ) {
     public Exam toEntity() {
         return new Exam(
@@ -23,8 +22,8 @@ public record ExamCreateRequest(
                 0.0,
                 0,
                 certificationType,
-                subjectDtoList != null ?
-                        subjectDtoList.stream().map(SubjectDto::toEntity).toList() :
+                subjects != null ?
+                        subjects.stream().map(SubjectDto::toEntity).toList() :
                         List.of()
         );
     }

--- a/src/main/java/com/example/masterplanbbe/domain/exam/response/CreateExamResponse.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/response/CreateExamResponse.java
@@ -12,7 +12,7 @@ public record CreateExamResponse(
         String title,
         Category category,
         String authority,
-        List<SubjectDto> subjectDtoList
+        List<SubjectDto> subjects
 ) {
     public CreateExamResponse(Exam exam){
         this(

--- a/src/main/java/com/example/masterplanbbe/domain/exam/response/UpdateExamResponse.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/response/UpdateExamResponse.java
@@ -2,16 +2,16 @@ package com.example.masterplanbbe.domain.exam.response;
 
 import com.example.masterplanbbe.domain.exam.dto.SubjectDto;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
-import com.example.masterplanbbe.domain.exam.entity.Subject;
 import com.example.masterplanbbe.domain.exam.enums.Category;
+import com.example.masterplanbbe.domain.exam.enums.CertificationType;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 public record UpdateExamResponse(
         Long examId,
         String title,
+        CertificationType certificationType,
         Category category,
         String authority,
         Double difficulty,
@@ -22,6 +22,7 @@ public record UpdateExamResponse(
         this(
                 exam.getId(),
                 exam.getTitle(),
+                exam.getCertificationType(),
                 exam.getCategory(),
                 exam.getAuthority(),
                 exam.getDifficulty(),

--- a/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
@@ -3,10 +3,13 @@ package com.example.masterplanbbe.domain.exam.controller;
 import com.example.masterplanbbe.common.jackson.RestPage;
 import com.example.masterplanbbe.common.response.ApiResponse;
 import com.example.masterplanbbe.domain.exam.dto.ExamItemCardDto;
+import com.example.masterplanbbe.domain.exam.dto.SubjectDto;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.entity.ExamBookmark;
 import com.example.masterplanbbe.domain.exam.request.ExamCreateRequest;
+import com.example.masterplanbbe.domain.exam.request.ExamUpdateRequest;
 import com.example.masterplanbbe.domain.exam.response.CreateExamResponse;
+import com.example.masterplanbbe.domain.exam.response.UpdateExamResponse;
 import com.example.masterplanbbe.domain.exam.service.ExamService;
 import com.example.masterplanbbe.domain.fixture.ExamFixture;
 import com.example.masterplanbbe.member.entity.Member;
@@ -126,7 +129,7 @@ public class ExamControllerTest {
     @DisplayName("관리자는 시험을 추가한다.")
     void add_exam() throws Exception {
         ExamCreateRequest request = ExamFixture.createExamCreateRequest("exam1");
-        CreateExamResponse mockedResult = new CreateExamResponse(createSavedExamFrom(request));
+        CreateExamResponse mockedResult = new CreateExamResponse(createExistingExamFrom(request));
         given(examService.create(any(ExamCreateRequest.class))).willReturn(mockedResult);
 
         ResultActions resultActions = mockMvc.perform(post("/api/v1/exam")
@@ -152,10 +155,61 @@ public class ExamControllerTest {
                 });
     }
 
-    private Exam createSavedExamFrom(ExamCreateRequest request) {
+    private Exam createExistingExamFrom(ExamCreateRequest request) {
         Exam exam = request.toEntity();
         setField(exam, "id", 1L);
         return exam;
+    }
+
+    @Test
+    @DisplayName("관리자는 시험을 수정한다.")
+    void update_exam() throws Exception {
+        Long examId = 1L;
+        ExamUpdateRequest request = ExamFixture.createExamUpdateRequest("exam1");
+        Exam exam = createExistingExamFrom(request);
+        given(examService.update(any(Long.class), any(ExamUpdateRequest.class))).willReturn(new UpdateExamResponse(exam));
+
+        ResultActions resultActions = mockMvc.perform(patch("/api/v1/exam/{examId}", examId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(UTF_8)
+                .content(objectMapper.writeValueAsString(request))
+                .accept(MediaType.APPLICATION_JSON));
+
+        resultActions.andExpectAll(status().isOk(), content().contentType("application/json"))
+                .andDo(print())
+                .andDo(mvcResult -> {
+                    String responseContent = mvcResult.getResponse().getContentAsString(UTF_8);
+                    ApiResponse<UpdateExamResponse> response = objectMapper.readValue(responseContent, new TypeReference<>() {
+                    });
+                    UpdateExamResponse data = response.getData();
+                    assertAll(
+                            () -> assertThat(data.examId()).isNotNull(),
+                            () -> assertThat(data.title()).isEqualTo(request.title()),
+                            () -> assertThat(data.category()).isEqualTo(request.category()),
+                            () -> assertThat(data.authority()).isEqualTo(request.authority()),
+                            () -> assertThat(data.difficulty()).isEqualTo(request.difficulty()),
+                            () -> assertThat(data.participantCount()).isEqualTo(request.participantCount()),
+                            () -> assertThat(data.certificationType()).isEqualTo(request.certificationType()),
+                            () -> assertThat(data.subjects()).isEqualTo(request.subjects())
+                    );
+                });
+    }
+
+    private Exam createExistingExamFrom(ExamUpdateRequest request) {
+        Exam exam = Exam.builder()
+                .title(request.title())
+                .category(request.category())
+                .authority(request.authority())
+                .difficulty(request.difficulty())
+                .participantCount(request.participantCount())
+                .certificationType(request.certificationType())
+                .subjects(request.subjects().stream().map(SubjectDto::toEntity).toList())
+                .build();
+        setField(exam, "id", 1L);
+        return exam;
+    }
+
+    private void assertUpdateExamResponse(ResultActions resultActions) throws Exception {
     }
 
     @Test

--- a/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
@@ -159,7 +159,7 @@ public class ExamControllerTest {
     }
 
     @Test
-    @DisplayName("사용자는 시험을 삭제한다.")
+    @DisplayName("관리자는 시험을 삭제한다.")
     void delete_exam() throws Exception {
         Long examId = 1L;
         willDoNothing().given(examService).delete(any(Long.class));

--- a/src/test/java/com/example/masterplanbbe/domain/exam/entity/ExamTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/entity/ExamTest.java
@@ -1,4 +1,55 @@
 package com.example.masterplanbbe.domain.exam.entity;
 
+import com.example.masterplanbbe.domain.exam.request.ExamUpdateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.example.masterplanbbe.domain.fixture.ExamFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+@DisplayName("시험 엔티티 테스트")
 public class ExamTest {
+    @Test
+    @DisplayName("update 메서드는 시험 필드를 업데이트한다.")
+    void update_method_updates_exam_fields() {
+        Exam exam = getExistingExam("기존 시험");
+        ExamUpdateRequest request = createExamUpdateRequest("수정된 시험");
+
+        exam.update(request);
+
+        assertAll(
+                () -> assertThat(exam.getTitle()).isEqualTo(request.title()),
+                () -> assertThat(exam.getCategory()).isEqualTo(request.category()),
+                () -> assertThat(exam.getAuthority()).isEqualTo(request.authority()),
+                () -> assertThat(exam.getDifficulty()).isEqualTo(request.difficulty()),
+                () -> assertThat(exam.getParticipantCount()).isEqualTo(request.participantCount()),
+                () -> assertThat(exam.getCertificationType()).isEqualTo(request.certificationType())
+        );
+    }
+
+    private Exam getExistingExam(String title) {
+        Exam exam = createExam(title);
+        setField(exam, "id", 1L);
+        return exam;
+    }
+
+    @Test
+    @DisplayName("update 메서드는 요청에 새로운 과목이 포함되어 있으면 과목을 추가한다.")
+    void update_method_add_subjects_if_request_has_new_subjects() {
+        //TODO: implement this test
+    }
+
+    @Test
+    @DisplayName("updete 메서드는 요청에 과목 목록이 비어있으면 과목을 제거한다.")
+    void update_method_remove_subjects_if_request_has_removed_subjects() {
+        //TODO: implement this test
+    }
+
+    @Test
+    @DisplayName("update 메서드는 요청에 과목 목록이 null 이면 과목을 제거한다.")
+    void update_method_handle_null_subjects() {
+        //TODO: implement this test
+    }
 }

--- a/src/test/java/com/example/masterplanbbe/domain/exam/entity/ExamTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/entity/ExamTest.java
@@ -4,6 +4,8 @@ import com.example.masterplanbbe.domain.exam.request.ExamUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static com.example.masterplanbbe.domain.fixture.ExamFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -28,6 +30,8 @@ public class ExamTest {
                 () -> assertThat(exam.getCertificationType()).isEqualTo(request.certificationType())
         );
     }
+    //TODO: 기존 과목이 업데이트되는 동작과,
+    // 새로운 과목이 추가되는 동작을 구분하여 검증할 수 있게 테스트 코드와 fixture 를 변경해야 함
 
     private Exam getExistingExam(String title) {
         Exam exam = createExam(title);
@@ -38,18 +42,36 @@ public class ExamTest {
     @Test
     @DisplayName("update 메서드는 요청에 새로운 과목이 포함되어 있으면 과목을 추가한다.")
     void update_method_add_subjects_if_request_has_new_subjects() {
-        //TODO: implement this test
+        Exam exam = getExistingExam("기존 시험");
+        ExamUpdateRequest request = createExamUpdateRequest("수정된 시험", exam, List.of("추가된 과목"));
+
+        exam.update(request);
+
+        assert exam.getSubjects() != null;
+        assertThat(exam.getSubjects().stream().map(Subject::getTitle)).contains("추가된 과목");
     }
 
     @Test
     @DisplayName("updete 메서드는 요청에 과목 목록이 비어있으면 과목을 제거한다.")
     void update_method_remove_subjects_if_request_has_removed_subjects() {
-        //TODO: implement this test
+        Exam exam = getExistingExam("기존 시험");
+        ExamUpdateRequest request = createExamUpdateRequest("수정된 시험", exam, List.of());
+
+        exam.update(request);
+
+        assert exam.getSubjects() != null;
+        assertThat(exam.getSubjects()).isEmpty();
     }
 
     @Test
     @DisplayName("update 메서드는 요청에 과목 목록이 null 이면 과목을 제거한다.")
     void update_method_handle_null_subjects() {
-        //TODO: implement this test
+        Exam exam = getExistingExam("기존 시험");
+        ExamUpdateRequest request = createExamUpdateRequest("수정된 시험", exam, null);
+
+        exam.update(request);
+
+        assert exam.getSubjects() != null;
+        assertThat(exam.getSubjects().stream().map(Subject::getTitle)).isEmpty();
     }
 }

--- a/src/test/java/com/example/masterplanbbe/domain/exam/entity/ExamTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/entity/ExamTest.java
@@ -1,0 +1,4 @@
+package com.example.masterplanbbe.domain.exam.entity;
+
+public class ExamTest {
+}

--- a/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
@@ -19,7 +19,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 

--- a/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
@@ -5,6 +5,7 @@ import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.entity.ExamBookmark;
 import com.example.masterplanbbe.domain.exam.repository.ExamRepositoryPort;
 import com.example.masterplanbbe.domain.exam.request.ExamCreateRequest;
+import com.example.masterplanbbe.domain.exam.request.ExamUpdateRequest;
 import com.example.masterplanbbe.domain.exam.response.CreateExamResponse;
 import com.example.masterplanbbe.member.entity.Member;
 import com.example.masterplanbbe.utils.TestUtils;
@@ -22,8 +23,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
-import static com.example.masterplanbbe.domain.fixture.ExamFixture.createExam;
-import static com.example.masterplanbbe.domain.fixture.ExamFixture.createExamCreateRequest;
+import static com.example.masterplanbbe.domain.fixture.ExamFixture.*;
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -100,6 +100,31 @@ public class ExamServiceTest {
                 () -> invocation.getArgument(0),
                 exam -> setField(exam, "id", 1L)
         );
+    }
+
+    @Test
+    @DisplayName("관리자는 시험을 수정한다.")
+    void update_exam() {
+        Long examId = 1L;
+        Exam exam = getExistingExamById(examId);
+        ExamUpdateRequest request = createExamUpdateRequest("수정된 시험");
+        given(examRepositoryPort.getById(any(Long.class))).willReturn(exam);
+
+        examService.update(examId, request);
+
+        verify(examRepositoryPort, times(1)).getById(any(Long.class));
+        assertAll(
+                () -> assertThat(exam.getTitle()).isEqualTo(request.title()),
+                () -> assertThat(exam.getCategory()).isEqualTo(request.category()),
+                () -> assertThat(exam.getAuthority()).isEqualTo(request.authority()),
+                () -> assertThat(exam.getSubjects()).isEqualTo(request.subjects())
+        );
+    }
+
+    private Exam getExistingExamById(Long examId) {
+        Exam exam = createExam("exam1");
+        setField(exam, "id", examId);
+        return exam;
     }
 
     @Test

--- a/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.masterplanbbe.domain.exam.service;
 
 import com.example.masterplanbbe.domain.exam.dto.ExamItemCardDto;
+import com.example.masterplanbbe.domain.exam.dto.SubjectDto;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.entity.ExamBookmark;
 import com.example.masterplanbbe.domain.exam.repository.ExamRepositoryPort;
@@ -117,7 +118,10 @@ public class ExamServiceTest {
                 () -> assertThat(exam.getTitle()).isEqualTo(request.title()),
                 () -> assertThat(exam.getCategory()).isEqualTo(request.category()),
                 () -> assertThat(exam.getAuthority()).isEqualTo(request.authority()),
-                () -> assertThat(exam.getSubjects()).isEqualTo(request.subjects())
+                () -> {
+                    assert exam.getSubjects() != null;
+                    assertThat(exam.getSubjects().stream().map(SubjectDto::new)).isEqualTo(request.subjects());
+                }
         );
     }
 

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/ExamFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/ExamFixture.java
@@ -2,12 +2,11 @@ package com.example.masterplanbbe.domain.fixture;
 
 import com.example.masterplanbbe.domain.exam.dto.SubjectDto;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
-import com.example.masterplanbbe.domain.exam.entity.Subject;
 import com.example.masterplanbbe.domain.exam.request.ExamCreateRequest;
 import com.example.masterplanbbe.domain.exam.request.ExamUpdateRequest;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.example.masterplanbbe.domain.exam.enums.Category.IT_ICT;
 import static com.example.masterplanbbe.domain.exam.enums.CertificationType.*;
@@ -20,6 +19,7 @@ public class ExamFixture {
                 .authority("테스트")
                 .participantCount(100)
                 .difficulty(3.0)
+                .subjects(new ArrayList<>())
                 .build();
     }
 
@@ -31,11 +31,16 @@ public class ExamFixture {
         return new ExamUpdateRequest(title, IT_ICT, "테스트", 3.0, 100, NATIONAL_CERTIFIED, List.of());
     }
 
-    public static ExamUpdateRequest createUpdateRequestWithSubject(String title, Exam exam, List<Subject> subjects) {
-        List<SubjectDto> subjectDtoList = subjects.stream()
-                .map(SubjectDto::new)
-                .toList();
-        return new ExamUpdateRequest(title, IT_ICT, "테스트", 3.0, 100, NATIONAL_CERTIFIED, subjectDtoList);
+    public static ExamUpdateRequest createExamUpdateRequest(String title,
+                                                            Exam exam,
+                                                            List<String> subjectTitles) {
+        List<SubjectDto> subjects = subjectTitles != null ? new ArrayList<>() : null;
+        if (subjectTitles != null) {
+            for (int i = 0; i < subjectTitles.size(); i++) {
+                subjects.add(new SubjectDto(i + 1L, exam.getId(), subjectTitles.get(i), "설명"));
+            }
+        }
+        return new ExamUpdateRequest(title, IT_ICT, "테스트", 3.0, 100, NATIONAL_CERTIFIED, subjects);
     }
 
 }

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/ExamFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/ExamFixture.java
@@ -1,9 +1,13 @@
 package com.example.masterplanbbe.domain.fixture;
 
+import com.example.masterplanbbe.domain.exam.dto.SubjectDto;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
+import com.example.masterplanbbe.domain.exam.entity.Subject;
 import com.example.masterplanbbe.domain.exam.request.ExamCreateRequest;
+import com.example.masterplanbbe.domain.exam.request.ExamUpdateRequest;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.example.masterplanbbe.domain.exam.enums.Category.IT_ICT;
 import static com.example.masterplanbbe.domain.exam.enums.CertificationType.*;
@@ -22,4 +26,16 @@ public class ExamFixture {
     public static ExamCreateRequest createExamCreateRequest(String title) {
         return new ExamCreateRequest(title, IT_ICT, "테스트", NATIONAL_CERTIFIED, List.of());
     }
+
+    public static ExamUpdateRequest createExamUpdateRequest(String title) {
+        return new ExamUpdateRequest(title, IT_ICT, "테스트", 3.0, 100, NATIONAL_CERTIFIED, List.of());
+    }
+
+    public static ExamUpdateRequest createUpdateRequestWithSubject(String title, Exam exam, List<Subject> subjects) {
+        List<SubjectDto> subjectDtoList = subjects.stream()
+                .map(SubjectDto::new)
+                .toList();
+        return new ExamUpdateRequest(title, IT_ICT, "테스트", 3.0, 100, NATIONAL_CERTIFIED, subjectDtoList);
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

* 시험 수정 메서드의 엔티티 테스트를 작성했습니다.

* 시험 수정 메서드의 서비스 테스트를 작성했습니다.

* 시험 수정 메서드의 컨트롤러 테스트를 작성했습니다.
