### PR TITLE
회원 시험 일정 삭제 기능

### DIFF
--- a/src/main/java/com/example/masterplanbbe/domain/userExamSession/controller/UserExamSessionController.java
+++ b/src/main/java/com/example/masterplanbbe/domain/userExamSession/controller/UserExamSessionController.java
@@ -39,4 +39,17 @@ public class UserExamSessionController {
                 .body(ApiResponse.ok(userExamSessionService.update(request, updateId)));
     }
 
+    @Operation(summary = "회원 시험 일정 삭제")
+    @DeleteMapping(path = "/{exam-sessions-id}")
+    public ResponseEntity<ApiResponse<?>> delete(
+            @PathVariable(name = "exam-sessions-id") Long deleteId,
+            // TODO : security 적용 예정
+            Long memberId
+    ) {
+        userExamSessionService.delete(deleteId, memberId);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.ok("나의 시험 일정 삭제 성공"));
+    }
+
 }

--- a/src/main/java/com/example/masterplanbbe/domain/userExamSession/repository/UserExamSessionRepository.java
+++ b/src/main/java/com/example/masterplanbbe/domain/userExamSession/repository/UserExamSessionRepository.java
@@ -3,5 +3,8 @@ package com.example.masterplanbbe.domain.userExamSession.repository;
 import com.example.masterplanbbe.domain.userExamSession.entity.UserExamSession;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserExamSessionRepository extends JpaRepository<UserExamSession, Long> {
+    Optional<UserExamSession> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/com/example/masterplanbbe/domain/userExamSession/repository/UserExamSessionRepositoryAdapter.java
+++ b/src/main/java/com/example/masterplanbbe/domain/userExamSession/repository/UserExamSessionRepositoryAdapter.java
@@ -23,4 +23,17 @@ public class UserExamSessionRepositoryAdapter implements UserExamSessionReposito
     public UserExamSession getById(Long id) {
         return userExamSessionRepository.findById(id).orElseThrow(() -> new NotFoundException(NOT_FOUND_USER_EXAM_SESSION));
     }
+
+    @Override
+    public void delete(UserExamSession userExamSession) {
+        userExamSessionRepository.delete(userExamSession);
+    }
+
+    @Override
+    public UserExamSession findByIdAndMemberId(Long id, Long memberId) {
+        return userExamSessionRepository.findByIdAndMemberId(id, memberId).orElseThrow(
+                () -> new NotFoundException(NOT_FOUND_USER_EXAM_SESSION)
+        );
+
+    }
 }

--- a/src/main/java/com/example/masterplanbbe/domain/userExamSession/repository/UserExamSessionRepositoryPort.java
+++ b/src/main/java/com/example/masterplanbbe/domain/userExamSession/repository/UserExamSessionRepositoryPort.java
@@ -6,4 +6,8 @@ public interface UserExamSessionRepositoryPort {
     UserExamSession save(UserExamSession userExamSession);
 
     UserExamSession getById(Long id);
+
+    void delete(UserExamSession userExamSession);
+
+    UserExamSession findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/com/example/masterplanbbe/domain/userExamSession/service/UserExamSessionService.java
+++ b/src/main/java/com/example/masterplanbbe/domain/userExamSession/service/UserExamSessionService.java
@@ -41,4 +41,10 @@ public class UserExamSessionService {
 
         return UserExamSessionResponse.from(userExamSession);
     }
+
+    @Transactional
+    public void delete(Long deleteId, Long memberId) {
+        UserExamSession userExamSession = userExamSessionRepositoryPort.findByIdAndMemberId(deleteId, memberId);
+        userExamSessionRepositoryPort.delete(userExamSession);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #50 

<br/>

## 📝작업 내용

> 회원 시험 일정 삭제 기능 구현.
> 회원의 id와 삭제할 일정의 id를 통해 조회한 객체를 jpa의 delete()를 통해 삭제 진행.
> 이를 통해, 영속성 컨텍스트에 올라가있는 객체를 삭제 후, 트랜잭션 종료시 delete 쿼리 발생.
> deleteById()를 사용하려 했지만 이는 영속성 컨텍스트를 활용하지 않아 비효율적이라 생각되어 사용X.

<br/>

## 📷 스크린샷 (선택)



<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>

