### PR TITLE
회원 시험 일정 상세 조회 기능

### DIFF
--- a/src/main/java/com/example/masterplanbbe/domain/userExamSession/controller/UserExamSessionController.java
+++ b/src/main/java/com/example/masterplanbbe/domain/userExamSession/controller/UserExamSessionController.java
@@ -52,4 +52,15 @@ public class UserExamSessionController {
                 .body(ApiResponse.ok("나의 시험 일정 삭제 성공"));
     }
 
+    @Operation(summary = "회원 시험 일정 상세 조회")
+    @GetMapping(path = "/{exam-sessions-id}")
+    public ResponseEntity<ApiResponse<?>> findOne(
+            @PathVariable(name = "exam-sessions-id") Long id,
+            // TODO : security 적용 예정
+            Long memberId
+    ) {
+        return ResponseEntity.ok()
+                .body(ApiResponse.ok(userExamSessionService.findOne(id, memberId)));
+    }
+
 }

--- a/src/main/java/com/example/masterplanbbe/domain/userExamSession/dto/response/UserExamSessionDetailResponse.java
+++ b/src/main/java/com/example/masterplanbbe/domain/userExamSession/dto/response/UserExamSessionDetailResponse.java
@@ -1,0 +1,41 @@
+package com.example.masterplanbbe.domain.userExamSession.dto.response;
+
+import com.example.masterplanbbe.domain.exam.enums.CertificationType;
+import com.example.masterplanbbe.domain.userExamSession.entity.UserExamSession;
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDate;
+
+public record UserExamSessionDetailResponse(
+        Long id,
+        Long memberId,
+        CertificationType certificationType,
+        String title,
+        LocalDate date,
+        Long dueDate
+) {
+    public static UserExamSessionDetailResponse of(Long id, Long memberId, CertificationType certificationType, String title, LocalDate date, Long dueDate) {
+        return new UserExamSessionDetailResponse(id, memberId, certificationType, title, date, dueDate);
+    }
+
+    public static UserExamSessionDetailResponse from(UserExamSession userExamSession, Long dueDate) {
+        return UserExamSessionDetailResponse.of(
+                userExamSession.getId(),
+                userExamSession.getMember().getId(),
+                userExamSession.getExam().getCertificationType(),
+                userExamSession.getExam().getTitle(),
+                userExamSession.getDate(),
+                dueDate
+        );
+    }
+
+    @QueryProjection
+    public UserExamSessionDetailResponse(Long id, Long memberId, CertificationType certificationType, String title, LocalDate date, Long dueDate) {
+        this.id = id;
+        this.memberId = memberId;
+        this.certificationType = certificationType;
+        this.title = title;
+        this.date = date;
+        this.dueDate = dueDate;
+    }
+}

--- a/src/main/java/com/example/masterplanbbe/domain/userExamSession/repository/UserExamSessionRepositoryAdapter.java
+++ b/src/main/java/com/example/masterplanbbe/domain/userExamSession/repository/UserExamSessionRepositoryAdapter.java
@@ -1,12 +1,19 @@
 package com.example.masterplanbbe.domain.userExamSession.repository;
 
 import com.example.masterplanbbe.common.GlobalException.NotFoundException;
+import com.example.masterplanbbe.domain.userExamSession.dto.response.UserExamSessionDetailResponse;
 import com.example.masterplanbbe.domain.userExamSession.entity.UserExamSession;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 import static com.example.masterplanbbe.common.exception.ErrorCode.NOT_FOUND_USER_EXAM_SESSION;
+import static com.example.masterplanbbe.domain.userExamSession.entity.QUserExamSession.userExamSession;
 
 @Repository
 @RequiredArgsConstructor
@@ -35,5 +42,24 @@ public class UserExamSessionRepositoryAdapter implements UserExamSessionReposito
                 () -> new NotFoundException(NOT_FOUND_USER_EXAM_SESSION)
         );
 
+    }
+
+    @Override
+    public UserExamSessionDetailResponse findDetailByIdAndMemberId(Long id, Long memberId) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .select(Projections.constructor(UserExamSessionDetailResponse.class,
+                                userExamSession.id,
+                                userExamSession.member.id,
+                                userExamSession.exam.certificationType,
+                                userExamSession.exam.title,
+                                userExamSession.date,
+                                Expressions.numberTemplate(Long.class, "DATEDIFF({0}, {1})", LocalDate.now(), userExamSession.date)
+                        ))
+                        .from(userExamSession)
+                        .where(userExamSession.id.eq(id)
+                                .and(userExamSession.member.id.eq(memberId)))
+                        .fetchOne()
+        ).orElseThrow(() -> new NotFoundException(NOT_FOUND_USER_EXAM_SESSION));
     }
 }

--- a/src/main/java/com/example/masterplanbbe/domain/userExamSession/repository/UserExamSessionRepositoryPort.java
+++ b/src/main/java/com/example/masterplanbbe/domain/userExamSession/repository/UserExamSessionRepositoryPort.java
@@ -1,5 +1,6 @@
 package com.example.masterplanbbe.domain.userExamSession.repository;
 
+import com.example.masterplanbbe.domain.userExamSession.dto.response.UserExamSessionDetailResponse;
 import com.example.masterplanbbe.domain.userExamSession.entity.UserExamSession;
 
 public interface UserExamSessionRepositoryPort {
@@ -10,4 +11,6 @@ public interface UserExamSessionRepositoryPort {
     void delete(UserExamSession userExamSession);
 
     UserExamSession findByIdAndMemberId(Long id, Long memberId);
+
+    UserExamSessionDetailResponse findDetailByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/com/example/masterplanbbe/domain/userExamSession/service/UserExamSessionService.java
+++ b/src/main/java/com/example/masterplanbbe/domain/userExamSession/service/UserExamSessionService.java
@@ -3,6 +3,7 @@ package com.example.masterplanbbe.domain.userExamSession.service;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.repository.ExamRepositoryPort;
 import com.example.masterplanbbe.domain.userExamSession.dto.request.UserExamSessionRequest;
+import com.example.masterplanbbe.domain.userExamSession.dto.response.UserExamSessionDetailResponse;
 import com.example.masterplanbbe.domain.userExamSession.dto.response.UserExamSessionResponse;
 import com.example.masterplanbbe.domain.userExamSession.entity.UserExamSession;
 import com.example.masterplanbbe.domain.userExamSession.repository.UserExamSessionRepositoryPort;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserExamSessionService {
 
     private final ExamRepositoryPort examRepositoryPort;
@@ -46,5 +48,9 @@ public class UserExamSessionService {
     public void delete(Long deleteId, Long memberId) {
         UserExamSession userExamSession = userExamSessionRepositoryPort.findByIdAndMemberId(deleteId, memberId);
         userExamSessionRepositoryPort.delete(userExamSession);
+    }
+
+    public UserExamSessionDetailResponse findOne(Long id, Long memberId) {
+        return userExamSessionRepositoryPort.findDetailByIdAndMemberId(id, memberId);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #50 

<br/>

## 📝작업 내용

> 회원 시험 일정 상세 조회 기능 구현.
> 기존 작성했던 쿼리 메서드를 통한 조회시, select 쿼리가 두번 발생(ExamDetail에 대한 지연로딩)
> Querydsl을 통해 response 하나로 묶어 select 쿼리 한번만 발생하도록 수정.

<br/>

## 📷 스크린샷 (선택)

> 이미지가 있다면 첨부해주세요

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
