### PR TITLE
fix: 테스트 코드에 있던 멤버 참조 일부 수정

### DIFF
--- a/src/test/java/com/example/masterplanbbe/domain/fixture/MemberFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/MemberFixture.java
@@ -1,22 +1,27 @@
 package com.example.masterplanbbe.domain.fixture;
 
-import com.example.masterplanbbe.member.entity.Member;
+import com.example.masterplanbbe.domain.member.dto.MemberCreateRequestDTO;
+import com.example.masterplanbbe.domain.member.entity.Member;
+import com.example.masterplanbbe.domain.member.entity.MemberRoleEnum;
 import com.example.masterplanbbe.utils.TestUtils;
 
 import java.time.LocalDate;
 
+import static com.example.masterplanbbe.domain.member.entity.MemberRoleEnum.*;
+
 public class MemberFixture {
     public static Member createMember() {
-        return Member.builder()
-                .userId("test")
-                .email("test@test.com")
-                .name("name")
-                .nickname("nickname")
-                .password("password")
-                .phoneNumber("010-1234-5678")
-                .birthday(LocalDate.parse("1999-01-01"))
-                .profileImageUrl("profileImageUrl")
-                .build();
+        MemberCreateRequestDTO requestDTO = new MemberCreateRequestDTO(
+                "test@test.com",
+                "nickname",
+                "password",
+                false
+        );
+        return new Member(
+                requestDTO,
+                "password",
+                USER
+        );
     }
 
     public static Member createExistingMember() {

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/SpecBookmarkFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/SpecBookmarkFixture.java
@@ -1,8 +1,8 @@
 package com.example.masterplanbbe.domain.fixture;
 
+import com.example.masterplanbbe.domain.member.entity.Member;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.example.masterplanbbe.domain.specBookmark.entity.SpecBookmark;
-import com.example.masterplanbbe.member.entity.Member;
 import com.example.masterplanbbe.utils.TestUtils;
 
 public class SpecBookmarkFixture {

--- a/src/test/java/com/example/masterplanbbe/domain/post/service/LikePostServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/post/service/LikePostServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.masterplanbbe.domain.post.service;
 
+import com.example.masterplanbbe.domain.fixture.MemberFixture;
 import com.example.masterplanbbe.domain.post.dto.PostResponse;
 import com.example.masterplanbbe.domain.post.entity.Post;
 import com.example.masterplanbbe.domain.post.repository.PostRepositoryPort;
@@ -17,6 +18,7 @@ import org.springframework.data.redis.core.ValueOperations;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
@@ -48,12 +50,7 @@ public class LikePostServiceTest {
         // Given
         Long postId = 1L;
         Long memberId = 1L;
-        Member member = Member.builder()
-                .email("test@naver.com")
-                .name("테스트")
-                .userId("test")
-                .password("test")
-                .build();
+        Member member = createMember();
         when(memberRepositoryPort.findById(memberId)).thenReturn(member);
 
         Post post = Post.builder()
@@ -91,12 +88,7 @@ public class LikePostServiceTest {
         // Given
         Long postId = 1L;
         Long memberId = 1L;
-        Member member = Member.builder()
-                .email("test@naver.com")
-                .name("테스트")
-                .userId("test")
-                .password("test")
-                .build();
+        Member member = createMember();
         when(memberRepositoryPort.findById(memberId)).thenReturn(member);
 
         Post post = Post.fullBuilder()

--- a/src/test/java/com/example/masterplanbbe/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/post/service/PostServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.masterplanbbe.domain.post.service;
 
+import com.example.masterplanbbe.domain.fixture.MemberFixture;
 import com.example.masterplanbbe.domain.post.dto.PostRequest;
 import com.example.masterplanbbe.domain.post.dto.PostResponse;
 import com.example.masterplanbbe.domain.post.entity.Category;
@@ -17,6 +18,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 
+import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
@@ -122,16 +124,7 @@ class PostServiceTest {
     }
 
     private static Member getMember() {
-        Member member = Member.builder()
-                .userId("user123")
-                .email("test@example.com")
-                .name("Test User")
-                .nickname("TestNick")
-                .password("password123")
-                .phoneNumber("010-1234-5678")
-                .birthday(LocalDate.of(1995, 5, 20))
-                .profileImageUrl("http://image.url")
-                .build();
+        Member member = createMember();
         ReflectionTestUtils.setField(member, "id", 1L);
         return member;
     }

--- a/src/test/java/com/example/masterplanbbe/domain/post/service/StoredPostServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/post/service/StoredPostServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.masterplanbbe.domain.post.service;
 
+import com.example.masterplanbbe.domain.fixture.MemberFixture;
 import com.example.masterplanbbe.domain.post.dto.PostResponse;
 import com.example.masterplanbbe.domain.post.entity.Category;
 import com.example.masterplanbbe.domain.post.entity.Post;
@@ -21,6 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.LocalDate;
 import java.util.List;
 
+import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -98,16 +100,7 @@ class StoredPostServiceTest {
     }
 
     private static Member getMember() {
-        Member member = Member.builder()
-                .userId("user123")
-                .email("test@example.com")
-                .name("Test User")
-                .nickname("TestNick")
-                .password("password123")
-                .phoneNumber("010-1234-5678")
-                .birthday(LocalDate.of(1995, 5, 20))
-                .profileImageUrl("http://image.url")
-                .build();
+        Member member = createMember();
         ReflectionTestUtils.setField(member, "id", 1L);
         return member;
     }

--- a/src/test/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryPortTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryPortTest.java
@@ -3,12 +3,12 @@ package com.example.masterplanbbe.domain.spec.repository;
 
 import com.example.masterplanbbe.common.exception.GlobalException;
 import com.example.masterplanbbe.domain.exam.repository.ExamRepository;
+import com.example.masterplanbbe.domain.member.entity.Member;
+import com.example.masterplanbbe.domain.member.repository.MemberRepository;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.dto.SpecWithDetailsDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.example.masterplanbbe.domain.specBookmark.repository.SpecBookmarkRepository;
-import com.example.masterplanbbe.member.entity.Member;
-import com.example.masterplanbbe.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.masterplanbbe.domain.spec.service;
 
 import com.example.masterplanbbe.domain.fixture.MemberFixture;
+import com.example.masterplanbbe.domain.member.entity.Member;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.dto.SpecWithDetailsDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
@@ -11,7 +12,6 @@ import com.example.masterplanbbe.domain.spec.response.CreateSpecResponse;
 import com.example.masterplanbbe.domain.spec.response.ReadSpecResponse;
 import com.example.masterplanbbe.domain.spec.response.UpdateSpecResponse;
 import com.example.masterplanbbe.domain.specBookmark.entity.SpecBookmark;
-import com.example.masterplanbbe.member.entity.Member;
 import com.example.masterplanbbe.utils.TestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +25,7 @@ import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
+import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 import static com.example.masterplanbbe.domain.fixture.SpecBookmarkFixture.createSpecBookmark;
 import static com.example.masterplanbbe.domain.fixture.SpecFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,7 +46,7 @@ public class SpecServiceTest {
     @Test
     @DisplayName("사용자는 스펙을 조회하고 북마크 여부를 확인한다.")
     void get_spec_and_check_bookmark() {
-        Member member = MemberFixture.createMember();
+        Member member = createMember();
         PageRequest pageRequest = PageRequest.of(0, 25);
         Page<SpecItemCardDto> mocked = createMockedSpecItemCardPage(member);
         given(specRepositoryPort.getSpecItemCards(pageRequest, member.getId())).willReturn(mocked);

--- a/src/test/java/com/example/masterplanbbe/domain/specBookmark/service/SpecBookmarkServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/specBookmark/service/SpecBookmarkServiceTest.java
@@ -1,12 +1,12 @@
 package com.example.masterplanbbe.domain.specBookmark.service;
 
+import com.example.masterplanbbe.domain.member.entity.Member;
+import com.example.masterplanbbe.domain.member.repository.MemberRepositoryPort;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.example.masterplanbbe.domain.spec.repository.SpecRepositoryPort;
 import com.example.masterplanbbe.domain.specBookmark.entity.SpecBookmark;
 import com.example.masterplanbbe.domain.specBookmark.repository.SpecBookmarkRepository;
 import com.example.masterplanbbe.domain.specBookmark.response.CreateSpecBookmarkResponse;
-import com.example.masterplanbbe.member.entity.Member;
-import com.example.masterplanbbe.member.repository.MemberRepositoryPort;
 import com.example.masterplanbbe.utils.TestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

### 1. MemberFixture를 Member 생성자에 맞게 변경

```java
public static Member createMember() {
        MemberCreateRequestDTO requestDTO = new MemberCreateRequestDTO(
                "test@test.com",
                "nickname",
                "password",
                false
        );
        return new Member(
                requestDTO,
                "password",
                USER
        );
    }
```

테스트 편의에 맞춘 Builder를 쓰지 않고, 
기존 생성자를 활용하도록 고쳤습니다.

작성해둔 다른 entityFixture 들도 똑같이 적용하여
테스트에만 사용되는 코드가 원본 패키지에 포함되지 않도록
리팩토링해야겠다는 생각이 듭니다.

### 2. StoredPostServiceTest.getMember의 Member 생성 방법 변경

```java
private static Member getMember() {
        Member member = createMember();
        ReflectionTestUtils.setField(member, "id", 1L);
        return member;
    }
```

영속화를 모방한 코드를 잘 사용해주셨습니다.
유일성 식별이 필요할 때 요긴했어서 같은 이점을 살릴 수 있으면 좋겠고,

</br>

```java
    public static Member createExistingMember() {
        return TestUtils.createExistingEntity(MemberFixture::createMember);
    }
```

스펙 관련 PR에서 
MemberFixture.createExistingMember를 작업해두어서, 이 메서드를 쓰셔도 좋을 거 같습니다.
getMember와 같은 기능을 가지는 public 메서드라 변경점을 하나로 줄일 수 있겠습니다.
