### PR TITLE
Feat/sort:: QueryDSL 동적 정렬을 위한 enum 설계 및 요청, 응답 객체 작성

### DIFF
--- a/src/main/java/com/example/masterplanbbe/common/enums/SortOption.java
+++ b/src/main/java/com/example/masterplanbbe/common/enums/SortOption.java
@@ -1,0 +1,6 @@
+package com.example.masterplanbbe.common.enums;
+
+public interface SortOption {
+    String getSortField();
+    String getEntityAlias();
+}

--- a/src/main/java/com/example/masterplanbbe/common/page/CustomPage.java
+++ b/src/main/java/com/example/masterplanbbe/common/page/CustomPage.java
@@ -1,0 +1,4 @@
+package com.example.masterplanbbe.common.page;
+
+public class CustomPage {
+}

--- a/src/main/java/com/example/masterplanbbe/common/page/CustomPage.java
+++ b/src/main/java/com/example/masterplanbbe/common/page/CustomPage.java
@@ -1,4 +1,20 @@
 package com.example.masterplanbbe.common.page;
 
-public class CustomPage {
+import java.util.List;
+
+public record CustomPage<T>(
+        int page,
+        int size,
+        long totalElements,
+        List<T> content
+) {
+
+    public boolean hasNext() {
+        return getOffset() + content.size() < totalElements;
+    }
+
+    private int getOffset() {
+        return page * size;
+    }
+
 }

--- a/src/main/java/com/example/masterplanbbe/common/request/CustomPageRequest.java
+++ b/src/main/java/com/example/masterplanbbe/common/request/CustomPageRequest.java
@@ -2,10 +2,10 @@ package com.example.masterplanbbe.common.request;
 
 import com.example.masterplanbbe.common.enums.SortOption;
 
-public record CustomPageRequest (
+public record CustomPageRequest<T extends SortOption> (
         Integer page,
         Integer size,
-        SortOption sort,
+        T sort,
         Boolean isAsc
 ) {
     public Long getOffset() {

--- a/src/main/java/com/example/masterplanbbe/common/request/CustomPageRequest.java
+++ b/src/main/java/com/example/masterplanbbe/common/request/CustomPageRequest.java
@@ -1,0 +1,14 @@
+package com.example.masterplanbbe.common.request;
+
+import com.example.masterplanbbe.common.enums.SortOption;
+
+public record CustomPageRequest (
+        Integer page,
+        Integer size,
+        SortOption sort,
+        Boolean isAsc
+) {
+    public Long getOffset() {
+        return (long) page * size;
+    }
+}

--- a/src/main/java/com/example/masterplanbbe/common/response/PageResponse.java
+++ b/src/main/java/com/example/masterplanbbe/common/response/PageResponse.java
@@ -1,0 +1,27 @@
+package com.example.masterplanbbe.common.response;
+
+import java.util.List;
+
+public record CustomPageResponse<T>(
+        int page,
+        int size,
+        long totalElements,
+        List<T> content
+) {
+
+    public int getTotalPages() {
+        return (int) Math.ceil((double) totalElements / size);
+    }
+
+    public int getOffset() {
+        return page * size;
+    }
+
+    public boolean hasPrevious() {
+        return page > 0;
+    }
+
+    public boolean hasNext() {
+        return getOffset() + content.size() < totalElements;
+    }
+}

--- a/src/main/java/com/example/masterplanbbe/common/response/PageResponse.java
+++ b/src/main/java/com/example/masterplanbbe/common/response/PageResponse.java
@@ -1,27 +1,17 @@
 package com.example.masterplanbbe.common.response;
 
+import com.example.masterplanbbe.common.page.CustomPage;
+
 import java.util.List;
 
-public record CustomPageResponse<T>(
+public record PageResponse<T>(
         int page,
         int size,
         long totalElements,
-        List<T> content
+        List<T> content,
+        boolean hasNext
 ) {
-
-    public int getTotalPages() {
-        return (int) Math.ceil((double) totalElements / size);
-    }
-
-    public int getOffset() {
-        return page * size;
-    }
-
-    public boolean hasPrevious() {
-        return page > 0;
-    }
-
-    public boolean hasNext() {
-        return getOffset() + content.size() < totalElements;
+    public PageResponse(CustomPage<T> customPage) {
+        this(customPage.page(), customPage.size(), customPage.totalElements(), customPage.content(), customPage.hasNext());
     }
 }

--- a/src/main/java/com/example/masterplanbbe/common/util/CustomPageUtils.java
+++ b/src/main/java/com/example/masterplanbbe/common/util/CustomPageUtils.java
@@ -1,0 +1,4 @@
+package com.example.masterplanbbe.common.util;
+
+public class CustomPageUtils {
+}

--- a/src/main/java/com/example/masterplanbbe/common/util/CustomPageUtils.java
+++ b/src/main/java/com/example/masterplanbbe/common/util/CustomPageUtils.java
@@ -1,5 +1,6 @@
 package com.example.masterplanbbe.common.util;
 
+import com.example.masterplanbbe.common.enums.SortOption;
 import com.example.masterplanbbe.common.page.CustomPage;
 import com.example.masterplanbbe.common.request.CustomPageRequest;
 import io.jsonwebtoken.lang.Assert;
@@ -11,7 +12,7 @@ public abstract class CustomPageUtils {
     private CustomPageUtils() {
     }
 
-    public static <T> CustomPage<T> getPage(List<T> content, CustomPageRequest pageRequest, LongSupplier totalSupplier) {
+    public static <T, U extends SortOption> CustomPage<T> getPage(List<T> content, CustomPageRequest<U> pageRequest, LongSupplier totalSupplier) {
         Assert.notNull(content, "content must not be null");
         Assert.notNull(totalSupplier, "totalSupplier must not be null");
         if (pageRequest.getOffset()  == 0) {

--- a/src/main/java/com/example/masterplanbbe/common/util/CustomPageUtils.java
+++ b/src/main/java/com/example/masterplanbbe/common/util/CustomPageUtils.java
@@ -1,4 +1,30 @@
 package com.example.masterplanbbe.common.util;
 
-public class CustomPageUtils {
+import com.example.masterplanbbe.common.page.CustomPage;
+import com.example.masterplanbbe.common.request.CustomPageRequest;
+import io.jsonwebtoken.lang.Assert;
+
+import java.util.List;
+import java.util.function.LongSupplier;
+
+public abstract class CustomPageUtils {
+    private CustomPageUtils() {
+    }
+
+    public static <T> CustomPage<T> getPage(List<T> content, CustomPageRequest pageRequest, LongSupplier totalSupplier) {
+        Assert.notNull(content, "content must not be null");
+        Assert.notNull(totalSupplier, "totalSupplier must not be null");
+        if (pageRequest.getOffset()  == 0) {
+            if (pageRequest.size() > content.size()) {
+                return new CustomPage<>(0, pageRequest.size(), content.size(), content);
+            }
+            return new CustomPage<>(0, pageRequest.size(), totalSupplier.getAsLong(), content);
+        }
+
+        if (!content.isEmpty() && pageRequest.size() > content.size()) {
+            return new CustomPage<>(pageRequest.page(), pageRequest.size(), pageRequest.getOffset() + content.size(), content);
+        }
+
+        return new CustomPage<>(pageRequest.page(), pageRequest.size(), totalSupplier.getAsLong(), content);
+    }
 }

--- a/src/main/java/com/example/masterplanbbe/common/util/SortUtil.java
+++ b/src/main/java/com/example/masterplanbbe/common/util/SortUtil.java
@@ -1,0 +1,24 @@
+package com.example.masterplanbbe.common.util;
+
+import com.example.masterplanbbe.common.enums.SortOption;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import org.springframework.data.util.Pair;
+
+import java.util.List;
+
+public class SortUtil {
+    public static OrderSpecifier<?> getOrderSpecifier(SortOption sortOption, boolean isAsc) {
+        Order order = isAsc ? Order.ASC : Order.DESC;
+        PathBuilder<?> path = new PathBuilder<>(Object.class, sortOption.getEntityAlias());
+
+        return new OrderSpecifier<>(order, path.getNumber(sortOption.getSortField(), Integer.class));
+    }
+
+    public static OrderSpecifier<?>[] getOrderSpecifiers(List<Pair<SortOption, Boolean>> sortOptions) {
+        return sortOptions.stream()
+                .map(sortOption -> getOrderSpecifier(sortOption.getFirst(), sortOption.getSecond()))
+                .toArray(OrderSpecifier[]::new);
+    }
+}

--- a/src/main/java/com/example/masterplanbbe/domain/spec/controller/SpecController.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/controller/SpecController.java
@@ -1,7 +1,10 @@
 package com.example.masterplanbbe.domain.spec.controller;
 
+import com.example.masterplanbbe.common.request.CustomPageRequest;
 import com.example.masterplanbbe.common.response.ApiResponse;
+import com.example.masterplanbbe.common.response.PageResponse;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
+import com.example.masterplanbbe.domain.spec.enums.SpecSortOption;
 import com.example.masterplanbbe.domain.spec.request.SpecCreateRequest;
 import com.example.masterplanbbe.domain.spec.request.SpecUpdateRequest;
 import com.example.masterplanbbe.domain.spec.response.CreateSpecResponse;
@@ -11,9 +14,6 @@ import com.example.masterplanbbe.domain.spec.service.SpecService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,12 +26,14 @@ public class SpecController {
 
     @Operation(summary = "스펙 목록 조회")
     @GetMapping
-    public ResponseEntity<ApiResponse<Page<SpecItemCardDto>>> getAllSpec(
-            @PageableDefault Pageable pageable,
-            @RequestParam(name = "memberId") Long memberId
-    ) {
+    public ResponseEntity<ApiResponse<PageResponse<SpecItemCardDto>>> getAllSpec(
+            @RequestBody CustomPageRequest request,
+            @RequestParam(name = "memberId") Long memberId,
+            @RequestParam(name = "sortOption", required = false)
+            SpecSortOption sortOption
+            ) {
         return ResponseEntity.ok()
-                .body(ApiResponse.ok(specService.getAllSpec(pageable, memberId)));
+                .body(ApiResponse.ok(specService.getAllSpec(request, memberId)));
     }
 
     @Operation(summary = "스펙 상세 조회")

--- a/src/main/java/com/example/masterplanbbe/domain/spec/controller/SpecController.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/controller/SpecController.java
@@ -27,10 +27,8 @@ public class SpecController {
     @Operation(summary = "스펙 목록 조회")
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<SpecItemCardDto>>> getAllSpec(
-            @RequestBody CustomPageRequest request,
-            @RequestParam(name = "memberId") Long memberId,
-            @RequestParam(name = "sortOption", required = false)
-            SpecSortOption sortOption
+            @RequestBody CustomPageRequest<SpecSortOption> request,
+            @RequestParam(name = "memberId") Long memberId
             ) {
         return ResponseEntity.ok()
                 .body(ApiResponse.ok(specService.getAllSpec(request, memberId)));

--- a/src/main/java/com/example/masterplanbbe/domain/spec/enums/SpecSortOption.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/enums/SpecSortOption.java
@@ -1,0 +1,4 @@
+package com.example.masterplanbbe.domain.spec.enums;
+
+public enum SpecSortOption {
+}

--- a/src/main/java/com/example/masterplanbbe/domain/spec/enums/SpecSortOption.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/enums/SpecSortOption.java
@@ -1,4 +1,24 @@
 package com.example.masterplanbbe.domain.spec.enums;
 
-public enum SpecSortOption {
+import com.example.masterplanbbe.common.enums.SortOption;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum SpecSortOption implements SortOption {
+    SCRAP_COUNT("scrapCount"),
+    REMAINING_DAYS("remainingDays"),
+    RECOMMENDED("recommended");
+
+    private final String fieldName;
+    private static final String ALIAS = "spec";
+
+    @Override
+    public String getSortField() {
+        return fieldName;
+    }
+
+    @Override
+    public String getEntityAlias() {
+        return ALIAS;
+    }
 }

--- a/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryAdapter.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryAdapter.java
@@ -3,11 +3,13 @@ package com.example.masterplanbbe.domain.spec.repository;
 import com.example.masterplanbbe.common.page.CustomPage;
 import com.example.masterplanbbe.common.request.CustomPageRequest;
 import com.example.masterplanbbe.common.util.CustomPageUtils;
+import com.example.masterplanbbe.common.util.SortUtil;
 import com.example.masterplanbbe.domain.spec.dto.QSpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.dto.QSpecWithDetailsDto;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.dto.SpecWithDetailsDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
+import com.example.masterplanbbe.domain.spec.enums.SpecSortOption;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLSubQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -33,7 +35,7 @@ public class SpecRepositoryAdapter implements SpecRepositoryPort, SpecRepository
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public CustomPage<SpecItemCardDto> getSpecItemCards(CustomPageRequest request,
+    public CustomPage<SpecItemCardDto> getSpecItemCards(CustomPageRequest<SpecSortOption> request,
                                                         Long memberId) {
         LocalDate today = LocalDate.now();
 
@@ -58,6 +60,7 @@ public class SpecRepositoryAdapter implements SpecRepositoryPort, SpecRepository
                 .leftJoin(specBookmark)
                 .on(specBookmark.spec.id.eq(spec.id).and(specBookmark.member.id.eq(memberId)))
                 .leftJoin(exam)
+                .orderBy(SortUtil.getOrderSpecifier(request.sort(), false))
                 .on(exam.id.eq(closestExamIdSubquery))
                 .offset(request.getOffset())
                 .limit(request.size())

--- a/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryAdapter.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryAdapter.java
@@ -1,5 +1,8 @@
 package com.example.masterplanbbe.domain.spec.repository;
 
+import com.example.masterplanbbe.common.page.CustomPage;
+import com.example.masterplanbbe.common.request.CustomPageRequest;
+import com.example.masterplanbbe.common.util.CustomPageUtils;
 import com.example.masterplanbbe.domain.spec.dto.QSpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.dto.QSpecWithDetailsDto;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
@@ -9,9 +12,6 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLSubQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -33,8 +33,8 @@ public class SpecRepositoryAdapter implements SpecRepositoryPort, SpecRepository
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<SpecItemCardDto> getSpecItemCards(Pageable pageable,
-                                                  Long memberId) {
+    public CustomPage<SpecItemCardDto> getSpecItemCards(CustomPageRequest request,
+                                                        Long memberId) {
         LocalDate today = LocalDate.now();
 
         JPQLSubQuery<Long> closestExamIdSubquery = JPAExpressions
@@ -59,8 +59,8 @@ public class SpecRepositoryAdapter implements SpecRepositoryPort, SpecRepository
                 .on(specBookmark.spec.id.eq(spec.id).and(specBookmark.member.id.eq(memberId)))
                 .leftJoin(exam)
                 .on(exam.id.eq(closestExamIdSubquery))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .offset(request.getOffset())
+                .limit(request.size())
                 .fetch();
 
         LongSupplier countQuery = () -> Optional.ofNullable(
@@ -70,7 +70,7 @@ public class SpecRepositoryAdapter implements SpecRepositoryPort, SpecRepository
                                 .fetchOne())
                 .orElse(0L);
 
-        return PageableExecutionUtils.getPage(list, pageable, countQuery);
+        return CustomPageUtils.getPage(list, request, countQuery);
     }
 
     @Override

--- a/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryCustom.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryCustom.java
@@ -1,11 +1,11 @@
 package com.example.masterplanbbe.domain.spec.repository;
 
+import com.example.masterplanbbe.common.page.CustomPage;
+import com.example.masterplanbbe.common.request.CustomPageRequest;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.dto.SpecWithDetailsDto;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 public interface SpecRepositoryCustom {
-    Page<SpecItemCardDto> getSpecItemCards(Pageable pageable, Long memberId);
+    CustomPage<SpecItemCardDto> getSpecItemCards(CustomPageRequest request, Long memberId);
     SpecWithDetailsDto getSpecWithDetails(Long specId);
 }

--- a/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryCustom.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryCustom.java
@@ -4,8 +4,9 @@ import com.example.masterplanbbe.common.page.CustomPage;
 import com.example.masterplanbbe.common.request.CustomPageRequest;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.dto.SpecWithDetailsDto;
+import com.example.masterplanbbe.domain.spec.enums.SpecSortOption;
 
 public interface SpecRepositoryCustom {
-    CustomPage<SpecItemCardDto> getSpecItemCards(CustomPageRequest request, Long memberId);
+    CustomPage<SpecItemCardDto> getSpecItemCards(CustomPageRequest<SpecSortOption> request, Long memberId);
     SpecWithDetailsDto getSpecWithDetails(Long specId);
 }

--- a/src/main/java/com/example/masterplanbbe/domain/spec/service/SpecService.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/service/SpecService.java
@@ -1,5 +1,7 @@
 package com.example.masterplanbbe.domain.spec.service;
 
+import com.example.masterplanbbe.common.request.CustomPageRequest;
+import com.example.masterplanbbe.common.response.PageResponse;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.example.masterplanbbe.domain.spec.repository.SpecRepositoryPort;
@@ -10,8 +12,6 @@ import com.example.masterplanbbe.domain.spec.response.ReadSpecResponse;
 import com.example.masterplanbbe.domain.spec.response.UpdateSpecResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -19,9 +19,9 @@ import org.springframework.stereotype.Service;
 public class SpecService {
     private final SpecRepositoryPort specRepositoryPort;
 
-    public Page<SpecItemCardDto> getAllSpec(Pageable pageable,
-                                            Long memberId) {
-        return specRepositoryPort.getSpecItemCards(pageable, memberId);
+    public PageResponse<SpecItemCardDto> getAllSpec(CustomPageRequest request,
+                                                    Long memberId) {
+        return new PageResponse<>(specRepositoryPort.getSpecItemCards(request, memberId));
     }
 
     public ReadSpecResponse getSpec(Long specId) {

--- a/src/main/java/com/example/masterplanbbe/domain/spec/service/SpecService.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/service/SpecService.java
@@ -4,6 +4,7 @@ import com.example.masterplanbbe.common.request.CustomPageRequest;
 import com.example.masterplanbbe.common.response.PageResponse;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
+import com.example.masterplanbbe.domain.spec.enums.SpecSortOption;
 import com.example.masterplanbbe.domain.spec.repository.SpecRepositoryPort;
 import com.example.masterplanbbe.domain.spec.request.SpecCreateRequest;
 import com.example.masterplanbbe.domain.spec.request.SpecUpdateRequest;
@@ -19,7 +20,7 @@ import org.springframework.stereotype.Service;
 public class SpecService {
     private final SpecRepositoryPort specRepositoryPort;
 
-    public PageResponse<SpecItemCardDto> getAllSpec(CustomPageRequest request,
+    public PageResponse<SpecItemCardDto> getAllSpec(CustomPageRequest<SpecSortOption> request,
                                                     Long memberId) {
         return new PageResponse<>(specRepositoryPort.getSpecItemCards(request, memberId));
     }

--- a/src/test/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryPortTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryPortTest.java
@@ -2,6 +2,8 @@ package com.example.masterplanbbe.domain.spec.repository;
 
 
 import com.example.masterplanbbe.common.exception.GlobalException;
+import com.example.masterplanbbe.common.page.CustomPage;
+import com.example.masterplanbbe.common.request.CustomPageRequest;
 import com.example.masterplanbbe.domain.exam.repository.ExamRepository;
 import com.example.masterplanbbe.domain.member.entity.Member;
 import com.example.masterplanbbe.domain.member.repository.MemberRepository;
@@ -53,16 +55,16 @@ public class SpecRepositoryPortTest {
         specRepositoryPort.saveAll(List.of(spec1, spec2));
         examRepository.save(createExam(spec1.getExamDetails().get(0)));
         specBookmarkRepository.save(createSpecBookmark(member, spec1));
-        PageRequest pageRequest = PageRequest.of(0, 25);
+        CustomPageRequest request = new CustomPageRequest(0, 25, null, false);
 
-        Page<SpecItemCardDto> result = specRepositoryPort.getSpecItemCards(pageRequest, member.getId());
+        CustomPage<SpecItemCardDto> result = specRepositoryPort.getSpecItemCards(request, member.getId());
 
-        assertThat(result.getContent().size()).isEqualTo(2);
+        assertThat(result.content().size()).isEqualTo(2);
         assertAll(
-                () -> assertThat(result.getContent().get(0).name()).isEqualTo(spec1.getName()),
-                () -> assertThat(result.getContent().get(1).name()).isEqualTo(spec2.getName()),
-                () -> assertThat(result.getContent().get(0).isBookmarked()).isTrue(),
-                () -> assertThat(result.getContent().get(1).isBookmarked()).isFalse()
+                () -> assertThat(result.content().get(0).name()).isEqualTo(spec1.getName()),
+                () -> assertThat(result.content().get(1).name()).isEqualTo(spec2.getName()),
+                () -> assertThat(result.content().get(0).isBookmarked()).isTrue(),
+                () -> assertThat(result.content().get(1).isBookmarked()).isFalse()
         );
     }
 

--- a/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
@@ -1,5 +1,8 @@
 package com.example.masterplanbbe.domain.spec.service;
 
+import com.example.masterplanbbe.common.page.CustomPage;
+import com.example.masterplanbbe.common.request.CustomPageRequest;
+import com.example.masterplanbbe.common.response.PageResponse;
 import com.example.masterplanbbe.domain.fixture.MemberFixture;
 import com.example.masterplanbbe.domain.member.entity.Member;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
@@ -13,6 +16,7 @@ import com.example.masterplanbbe.domain.spec.response.ReadSpecResponse;
 import com.example.masterplanbbe.domain.spec.response.UpdateSpecResponse;
 import com.example.masterplanbbe.domain.specBookmark.entity.SpecBookmark;
 import com.example.masterplanbbe.utils.TestUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,33 +51,33 @@ public class SpecServiceTest {
     @DisplayName("사용자는 스펙을 조회하고 북마크 여부를 확인한다.")
     void get_spec_and_check_bookmark() {
         Member member = createMember();
-        PageRequest pageRequest = PageRequest.of(0, 25);
-        Page<SpecItemCardDto> mocked = createMockedSpecItemCardPage(member);
-        given(specRepositoryPort.getSpecItemCards(pageRequest, member.getId())).willReturn(mocked);
+        CustomPageRequest request = new CustomPageRequest(0, 25, null, false);
+        CustomPage<SpecItemCardDto> mocked = createMockedSpecItemCardPage(member);
+        given(specRepositoryPort.getSpecItemCards(request, member.getId())).willReturn(mocked);
 
-        Page<SpecItemCardDto> result = specService.getAllSpec(pageRequest, member.getId());
+        PageResponse<SpecItemCardDto> result = specService.getAllSpec(request, member.getId());
 
-        verify(specRepositoryPort, times(1)).getSpecItemCards(pageRequest, member.getId());
+        verify(specRepositoryPort, times(1)).getSpecItemCards(request, member.getId());
         assertSpecItemCardPage(result);
     }
 
-    private Page<SpecItemCardDto> createMockedSpecItemCardPage(Member member) {
+    private CustomPage<SpecItemCardDto> createMockedSpecItemCardPage(Member member) {
         Spec spec1 = createExistingSpecFrom(1L);
         Spec spec2 = createExistingSpecFrom(2L);
         SpecBookmark specBookmark1 = createSpecBookmark(member, spec1);
 
-        return new PageImpl<>(List.of(
+        return new CustomPage<>(0, 25, 2, List.of(
                 new SpecItemCardDto(spec1, null, isBookmarkedBy(spec1, specBookmark1)),
                 new SpecItemCardDto(spec2, null, isBookmarkedBy(spec2, specBookmark1))
         ));
     }
 
-    private void assertSpecItemCardPage(Page<SpecItemCardDto> result) {
+    private void assertSpecItemCardPage(PageResponse<SpecItemCardDto> result) {
         assertThat(result).isNotNull();
         assertAll(
-                () -> assertThat(result.getContent().size()).isEqualTo(2),
-                () -> assertThat(result.getContent().get(0).isBookmarked()).isTrue(),
-                () -> assertThat(result.getContent().get(1).isBookmarked()).isFalse()
+                () -> assertThat(result.content().size()).isEqualTo(2),
+                () -> assertThat(result.content().get(0).isBookmarked()).isTrue(),
+                () -> assertThat(result.content().get(1).isBookmarked()).isFalse()
         );
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

* Page 객체의 필드 중 일부만 쓰는, PageResponse 레코드를 작성했습니다.

* QueryDSL 동적 정렬을 위한 enum을 설계했습니다.

* 해당 enum을 사용하기 위한 request 객체를 작성했습니다.

이하의 내용에서는 
각 구성요소 설명, 이로 인해 만족되는 요구사항을 순차적으로 적겠습니다.

- - -

## 구성 요소

### `SortOption` 인터페이스

```java
package com.example.masterplanbbe.common.enums;

public interface SortOption {
    String getSortField();
    String getEntityAlias();
}
```

String 값을 반환하는, 두 메서드를 가지고 있습니다.

### `SortUtil.getOrdesSpecifier` 메서드

```java
package com.example.masterplanbbe.common.util;

import com.querydsl.core.types.Order;
import com.querydsl.core.types.OrderSpecifier;
import com.querydsl.core.types.dsl.PathBuilder;

import java.util.List;

public class SortUtil {
    public static OrderSpecifier<?> getOrderSpecifier(SortOption sortOption, boolean isAsc) {
        Order order = isAsc ? Order.ASC : Order.DESC;
        PathBuilder<?> path = new PathBuilder<>(Object.class, sortOption.getEntityAlias());

        return new OrderSpecifier<>(order, path.getNumber(sortOption.getSortField(), Integer.class));
    }

    public static OrderSpecifier<?>[] getOrderSpecifiers(List<Pair<SortOption, Boolean>> sortOptions) {
        return sortOptions.stream()
                .map(sortOption -> getOrderSpecifier(sortOption.getFirst(), sortOption.getSecond()))
                .toArray(OrderSpecifier[]::new);
    }
}
```

QueryDSL의 동적 정렬에는 역시 QueryDSL 의존성이 있는, `OrderSpecifier`가 사용됩니다.
`SortOption` enum으로부터 OrderSpecifier 생성에 필요한 값을 얻습니다.

</br>

### `SpecSortOption` enum 클래스

```java
package com.example.masterplanbbe.domain.spec.enums;

@RequiredArgsConstructor
public enum SpecSortOption implements SortOption {
    SCRAP_COUNT("scrapCount"),
    REMAINING_DAYS("remainingDays"),
    RECOMMENDED("recommended");

    private final String fieldName;
    private static final String ALIAS = "spec";

    @Override
    public String getSortField() {
        return fieldName;
    }

    @Override
    public String getEntityAlias() {
        return ALIAS;
    }
}
```

`SortOption`을 구현한 enum 클래스입니다.
값 목록을 enum으로 제한하는 동시에
동적 정렬에 필요한 필드를 가지고 반환합니다.

### 요청 객체, `CustomPageRequest`
```java
package com.example.masterplanbbe.common.request;

public record CustomPageRequest<T extends SortOption> (
        Integer page,
        Integer size,
        T sort,
        Boolean isAsc
) {
    public Long getOffset() {
        return (long) page * size;
    }
}
```
`SortOption`을 상속하는 T 타입을 받도록 했습니다.

## 만족되는 요구사항

그래서 컨트롤러의 메서드 parameter에서 
* 구체화된 enum 클래스인
`SpecSortOption`으로 값 목록이 제한되고

* 이를 `OrderSpecifier`로 변환하는 로직은 `SortUtil.getOrderSpecifier` 를 통해
범용적으로 처리됩니다.