### PR TITLE
Feat/sort:: SpecAdapter 쿼리 메서드의 정렬 중 null 체크 추가 

### DIFF
--- a/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryAdapter.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryAdapter.java
@@ -60,7 +60,7 @@ public class SpecRepositoryAdapter implements SpecRepositoryPort, SpecRepository
                 .leftJoin(specBookmark)
                 .on(specBookmark.spec.id.eq(spec.id).and(specBookmark.member.id.eq(memberId)))
                 .leftJoin(exam)
-                .orderBy(SortUtil.getOrderSpecifier(request.sort(), false))
+                .orderBy(SortUtil.getOrderSpecifier(request.sort(), request.isAsc()))
                 .on(exam.id.eq(closestExamIdSubquery))
                 .offset(request.getOffset())
                 .limit(request.size())

--- a/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryAdapter.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryAdapter.java
@@ -10,6 +10,7 @@ import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.dto.SpecWithDetailsDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.example.masterplanbbe.domain.spec.enums.SpecSortOption;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLSubQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -50,6 +51,10 @@ public class SpecRepositoryAdapter implements SpecRepositoryPort, SpecRepository
                 .orderBy(exam.examStartDate.asc())
                 .limit(1);
 
+        OrderSpecifier<?> orderSpecifier = request.sort() != null ?
+                SortUtil.getOrderSpecifier(request.sort(), request.isAsc()) :
+                spec.createdAt.asc();
+
         List<SpecItemCardDto> list = queryFactory
                 .select(new QSpecItemCardDto(
                         spec,
@@ -60,7 +65,7 @@ public class SpecRepositoryAdapter implements SpecRepositoryPort, SpecRepository
                 .leftJoin(specBookmark)
                 .on(specBookmark.spec.id.eq(spec.id).and(specBookmark.member.id.eq(memberId)))
                 .leftJoin(exam)
-                .orderBy(SortUtil.getOrderSpecifier(request.sort(), request.isAsc()))
+                .orderBy(orderSpecifier)
                 .on(exam.id.eq(closestExamIdSubquery))
                 .offset(request.getOffset())
                 .limit(request.size())

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/SpecFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/SpecFixture.java
@@ -75,8 +75,8 @@ public class SpecFixture {
                 LANGUAGE,
                 ETC,
                 "ETS",
-                3.0,
-                100,
+                3.2,
+                120,
                 examDetails
         );
     }

--- a/src/test/java/com/example/masterplanbbe/domain/spec/entity/SpecTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/entity/SpecTest.java
@@ -1,0 +1,39 @@
+package com.example.masterplanbbe.domain.spec.entity;
+
+import com.example.masterplanbbe.domain.spec.request.SpecUpdateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.example.masterplanbbe.domain.fixture.SpecFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("스펙 엔티티 테스트")
+public class SpecTest {
+    @Test
+    @DisplayName("update 메서드는 스펙 엔티티의 필드를 수정한다.")
+    void update_updates_spec_fields() {
+        Spec spec = createExistingSpec();
+        SpecUpdateRequest request = createSpecUpdateRequest(spec.getExamDetails());
+
+        spec.update(
+                request.name(),
+                request.issuingOrganization(),
+                request.category(),
+                request.certificationType(),
+                request.difficulty(),
+                request.participantCount(),
+                request.examDetails()
+        );
+
+        assertAll(
+                () -> assertThat(spec.getName()).isEqualTo(request.name()),
+                () -> assertThat(spec.getIssuingOrganization()).isEqualTo(request.issuingOrganization()),
+                () -> assertThat(spec.getCategory()).isEqualTo(request.category()),
+                () -> assertThat(spec.getCertificationType()).isEqualTo(request.certificationType()),
+                () -> assertThat(spec.getDifficulty()).isEqualTo(request.difficulty()),
+                () -> assertThat(spec.getParticipantCount()).isEqualTo(request.participantCount()),
+                () -> assertThat(spec.getExamDetails()).isEqualTo(request.examDetails())
+        );
+    }
+}

--- a/src/test/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryPortTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryPortTest.java
@@ -10,6 +10,7 @@ import com.example.masterplanbbe.domain.member.repository.MemberRepository;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.dto.SpecWithDetailsDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
+import com.example.masterplanbbe.domain.spec.enums.SpecSortOption;
 import com.example.masterplanbbe.domain.specBookmark.repository.SpecBookmarkRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -55,7 +56,7 @@ public class SpecRepositoryPortTest {
         specRepositoryPort.saveAll(List.of(spec1, spec2));
         examRepository.save(createExam(spec1.getExamDetails().get(0)));
         specBookmarkRepository.save(createSpecBookmark(member, spec1));
-        CustomPageRequest request = new CustomPageRequest(0, 25, null, false);
+        CustomPageRequest<SpecSortOption> request = new CustomPageRequest<>(0, 25, null, false);
 
         CustomPage<SpecItemCardDto> result = specRepositoryPort.getSpecItemCards(request, member.getId());
 

--- a/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
@@ -8,6 +8,7 @@ import com.example.masterplanbbe.domain.member.entity.Member;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.dto.SpecWithDetailsDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
+import com.example.masterplanbbe.domain.spec.enums.SpecSortOption;
 import com.example.masterplanbbe.domain.spec.repository.SpecRepositoryPort;
 import com.example.masterplanbbe.domain.spec.request.SpecCreateRequest;
 import com.example.masterplanbbe.domain.spec.request.SpecUpdateRequest;
@@ -51,7 +52,7 @@ public class SpecServiceTest {
     @DisplayName("사용자는 스펙을 조회하고 북마크 여부를 확인한다.")
     void get_spec_and_check_bookmark() {
         Member member = createMember();
-        CustomPageRequest request = new CustomPageRequest(0, 25, null, false);
+        CustomPageRequest<SpecSortOption> request = new CustomPageRequest<>(0, 25, null, false);
         CustomPage<SpecItemCardDto> mocked = createMockedSpecItemCardPage(member);
         given(specRepositoryPort.getSpecItemCards(request, member.getId())).willReturn(mocked);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

동적으로 정렬 조건의 null 체크는 어렵지만,
CustomPageRequest의 sort 옵션은 nullable하게 두는 것이
PageRequest의 관례와 가까우므로

Adapter 클래스의 쿼리 메서드에서 null 체크를 하도록 했습니다.