### PR TITLE
Feat/spec:: Spec 컨트롤러 테스트 재작성, latestExam 외래키 필드 반영

### DIFF
--- a/src/main/java/com/example/masterplanbbe/domain/exam/entity/Exam.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/entity/Exam.java
@@ -18,7 +18,7 @@ public class Exam extends FullAuditEntity {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column
     private Double difficulty;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/masterplanbbe/domain/spec/controller/SpecController.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/controller/SpecController.java
@@ -27,7 +27,7 @@ public class SpecController {
     @Operation(summary = "스펙 목록 조회")
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<SpecItemCardDto>>> getAllSpec(
-            @RequestBody CustomPageRequest<SpecSortOption> request,
+            @ModelAttribute CustomPageRequest<SpecSortOption> request,
             @RequestParam(name = "memberId") Long memberId
             ) {
         return ResponseEntity.ok()

--- a/src/main/java/com/example/masterplanbbe/domain/spec/dto/SpecItemCardDto.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/dto/SpecItemCardDto.java
@@ -1,35 +1,40 @@
 package com.example.masterplanbbe.domain.spec.dto;
 
-import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.enums.Category;
-import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
 
 import java.time.LocalDate;
 
-public record SpecItemCardDto(
-        String name,
-        Category category,
-        Double difficulty,
-        Integer participants,
-        LocalDate applyStartDate,
-        LocalDate applyEndDate,
-        LocalDate examStartDate,
-        Boolean isBookmarked
-) {
+@Getter
+public class SpecItemCardDto {
+    private final String name;
+    private final Category category;
+    private final Double difficulty;
+    private final Integer participants;
+    private final LocalDate applyStartDate;
+    private final LocalDate applyEndDate;
+    private final LocalDate examStartDate;
+    private final Boolean isBookmarked;
+
     @QueryProjection
-    public SpecItemCardDto(Spec spec,
-                           Exam exam,
-                           Boolean isBookmarked) {
-        this(
-                spec.getName(),
-                spec.getCategory(),
-                exam != null ? exam.getDifficulty() : null,
-                exam != null ? exam.getParticipantCount() : null,
-                exam != null ? exam.getApplyStartDate() : null,
-                exam != null ? exam.getApplyEndDate() : null,
-                exam != null ? exam.getExamStartDate() : null,
-                isBookmarked
-        );
+    public SpecItemCardDto(
+            String name,
+            Category category,
+            Double difficulty,
+            Integer participants,
+            LocalDate applyStartDate,
+            LocalDate applyEndDate,
+            LocalDate examStartDate,
+            Boolean isBookmarked
+    ) {
+        this.name = name;
+        this.category = category;
+        this.difficulty = difficulty;
+        this.participants = participants;
+        this.applyStartDate = applyStartDate;
+        this.applyEndDate = applyEndDate;
+        this.examStartDate = examStartDate;
+        this.isBookmarked = isBookmarked;
     }
 }

--- a/src/main/java/com/example/masterplanbbe/domain/spec/dto/SpecItemCardDto.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/dto/SpecItemCardDto.java
@@ -2,10 +2,13 @@ package com.example.masterplanbbe.domain.spec.dto;
 
 import com.example.masterplanbbe.domain.exam.enums.Category;
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 @Getter
 public class SpecItemCardDto {
     private final String name;

--- a/src/main/java/com/example/masterplanbbe/domain/spec/dto/SpecWithDetailsDto.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/dto/SpecWithDetailsDto.java
@@ -1,11 +1,12 @@
 package com.example.masterplanbbe.domain.spec.dto;
 
-import com.example.masterplanbbe.domain.exam.entity.ExamDetail;
 import com.example.masterplanbbe.domain.exam.enums.CertificationType;
-import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 @Getter
 public class SpecWithDetailsDto {
     private final String name;

--- a/src/main/java/com/example/masterplanbbe/domain/spec/dto/SpecWithDetailsDto.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/dto/SpecWithDetailsDto.java
@@ -4,28 +4,37 @@ import com.example.masterplanbbe.domain.exam.entity.ExamDetail;
 import com.example.masterplanbbe.domain.exam.enums.CertificationType;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
 
-public record SpecWithDetailsDto(
-        String name,
-        String issuingOrganization,
-        CertificationType certificationType,
-        Boolean isBookmarked,
-        String preparation,
-        String eligibility,
-        String examStructure,
-        String passingCriteria
-) {
+@Getter
+public class SpecWithDetailsDto {
+    private final String name;
+    private final String issuingOrganization;
+    private final CertificationType certificationType;
+    private final Boolean isBookmarked;
+    private final String preparation;
+    private final String eligibility;
+    private final String examStructure;
+    private final String passingCriteria;
+
     @QueryProjection
-    public SpecWithDetailsDto(Spec spec, ExamDetail examDetail, Boolean isBookmarked) {
-        this(
-                spec.getName(),
-                spec.getIssuingOrganization(),
-                spec.getCertificationType(),
-                isBookmarked,
-                examDetail.getPreparation(),
-                examDetail.getEligibility(),
-                examDetail.getExamStructure(),
-                examDetail.getPassingCriteria()
-        );
+    public SpecWithDetailsDto(
+            String name,
+            String issuingOrganization,
+            CertificationType certificationType,
+            Boolean isBookmarked,
+            String preparation,
+            String eligibility,
+            String examStructure,
+            String passingCriteria
+    ) {
+        this.name = name;
+        this.issuingOrganization = issuingOrganization;
+        this.certificationType = certificationType;
+        this.isBookmarked = isBookmarked;
+        this.preparation = preparation;
+        this.eligibility = eligibility;
+        this.examStructure = examStructure;
+        this.passingCriteria = passingCriteria;
     }
 }

--- a/src/main/java/com/example/masterplanbbe/domain/spec/entity/Spec.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/entity/Spec.java
@@ -41,7 +41,7 @@ public class Spec extends FullAuditEntity {
     @OneToMany(mappedBy = "spec", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ExamDetail> examDetails;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     private Exam latestExam;
 
 
@@ -62,14 +62,13 @@ public class Spec extends FullAuditEntity {
         this.examDetails = examDetails != null ? examDetails : new ArrayList<>();
     }
 
-    public void update(String name, String issuingOrganization, Category category, CertificationType certificationType, Double difficulty, Integer participantCount, List<ExamDetail> examDetails) {
+    public void update(String name, String issuingOrganization, Category category, CertificationType certificationType, Double difficulty, Integer participantCount) {
         this.name = name;
         this.issuingOrganization = issuingOrganization;
         this.category = category;
         this.certificationType = certificationType;
         this.difficulty = difficulty;
         this.participantCount = participantCount;
-        this.examDetails = examDetails;
     }
 
     public void addExamDetail(ExamDetail examDetail) {

--- a/src/main/java/com/example/masterplanbbe/domain/spec/entity/Spec.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/entity/Spec.java
@@ -76,4 +76,7 @@ public class Spec extends FullAuditEntity {
         this.examDetails.add(examDetail);
     }
 
+    public void specifyLatestExam(Exam exam) {
+        this.latestExam = exam;
+    }
 }

--- a/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryAdapter.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryAdapter.java
@@ -21,9 +21,9 @@ import java.util.function.LongSupplier;
 
 import static com.example.masterplanbbe.common.exception.ErrorCode.SPEC_NOT_FOUND;
 import static com.example.masterplanbbe.common.exception.GlobalException.*;
-import static com.example.masterplanbbe.domain.exam.entity.QExam.*;
+import static com.example.masterplanbbe.domain.exam.entity.QExam.exam;
 import static com.example.masterplanbbe.domain.exam.entity.QExamDetail.examDetail;
-import static com.example.masterplanbbe.domain.spec.entity.QSpec.*;
+import static com.example.masterplanbbe.domain.spec.entity.QSpec.spec;
 import static com.example.masterplanbbe.domain.specBookmark.entity.QSpecBookmark.specBookmark;
 
 @Repository
@@ -41,8 +41,13 @@ public class SpecRepositoryAdapter implements SpecRepositoryPort, SpecRepository
 
         List<SpecItemCardDto> list = queryFactory
                 .select(new QSpecItemCardDto(
-                        spec,
-                        exam,
+                        spec.name,
+                        spec.category,
+                        spec.difficulty,
+                        spec.participantCount,
+                        exam.applyStartDate,
+                        exam.applyEndDate,
+                        exam.examStartDate,
                         specBookmark.isNotNull()
                 ))
                 .from(spec)

--- a/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryAdapter.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryAdapter.java
@@ -11,13 +11,10 @@ import com.example.masterplanbbe.domain.spec.dto.SpecWithDetailsDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.example.masterplanbbe.domain.spec.enums.SpecSortOption;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.JPQLSubQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.LongSupplier;
@@ -38,19 +35,6 @@ public class SpecRepositoryAdapter implements SpecRepositoryPort, SpecRepository
     @Override
     public CustomPage<SpecItemCardDto> getSpecItemCards(CustomPageRequest<SpecSortOption> request,
                                                         Long memberId) {
-        LocalDate today = LocalDate.now();
-
-        JPQLSubQuery<Long> closestExamIdSubquery = JPAExpressions
-                .select(exam.id)
-                .from(exam)
-                .join(exam.examDetail, examDetail)
-                .where(
-                        examDetail.spec.id.eq(spec.id)
-                                .and(exam.applyEndDate.goe(today))
-                )
-                .orderBy(exam.examStartDate.asc())
-                .limit(1);
-
         OrderSpecifier<?> orderSpecifier = request.sort() != null ?
                 SortUtil.getOrderSpecifier(request.sort(), request.isAsc()) :
                 spec.createdAt.asc();
@@ -65,8 +49,8 @@ public class SpecRepositoryAdapter implements SpecRepositoryPort, SpecRepository
                 .leftJoin(specBookmark)
                 .on(specBookmark.spec.id.eq(spec.id).and(specBookmark.member.id.eq(memberId)))
                 .leftJoin(exam)
+                .on(exam.id.eq(spec.latestExam.id))
                 .orderBy(orderSpecifier)
-                .on(exam.id.eq(closestExamIdSubquery))
                 .offset(request.getOffset())
                 .limit(request.size())
                 .fetch();
@@ -86,16 +70,23 @@ public class SpecRepositoryAdapter implements SpecRepositoryPort, SpecRepository
         return queryFactory
                 .select(
                         new QSpecWithDetailsDto(
-                                spec,
-                                examDetail,
-                                specBookmark.isNotNull()
+                                spec.name,
+                                spec.issuingOrganization,
+                                spec.certificationType,
+                                specBookmark.isNotNull(),
+                                examDetail.preparation,
+                                examDetail.eligibility,
+                                examDetail.examStructure,
+                                examDetail.passingCriteria
                         )
                 )
                 .from(spec)
                 .leftJoin(specBookmark)
                 .on(specBookmark.spec.id.eq(spec.id))
+                .leftJoin(exam)
+                .on(exam.id.eq(spec.latestExam.id))
                 .leftJoin(examDetail)
-                .on(examDetail.spec.id.eq(spec.id))
+                .on(examDetail.id.eq(exam.examDetail.id))
                 .fetchOne();
     }
 

--- a/src/main/java/com/example/masterplanbbe/domain/spec/request/SpecUpdateRequest.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/request/SpecUpdateRequest.java
@@ -1,11 +1,9 @@
 package com.example.masterplanbbe.domain.spec.request;
 
-import com.example.masterplanbbe.domain.exam.entity.ExamDetail;
 import com.example.masterplanbbe.domain.exam.enums.Category;
 import com.example.masterplanbbe.domain.exam.enums.CertificationType;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
 
-import java.util.List;
 
 public record SpecUpdateRequest(
         String name,
@@ -13,10 +11,9 @@ public record SpecUpdateRequest(
         CertificationType certificationType,
         String issuingOrganization,
         Double difficulty,
-        Integer participantCount,
-        List<ExamDetail> examDetails
+        Integer participantCount
 ) {
     public void update(Spec spec) {
-        spec.update(name, issuingOrganization, category, certificationType, difficulty, participantCount,examDetails);
+        spec.update(name, issuingOrganization, category, certificationType, difficulty, participantCount);
     }
 }

--- a/src/main/java/com/example/masterplanbbe/domain/spec/response/ReadSpecResponse.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/response/ReadSpecResponse.java
@@ -14,13 +14,13 @@ public record ReadSpecResponse(
 ) {
     public ReadSpecResponse(SpecWithDetailsDto dto) {
         this(
-                dto.name(),
-                dto.issuingOrganization(),
-                dto.certificationType(),
-                dto.preparation(),
-                dto.eligibility(),
-                dto.examStructure(),
-                dto.passingCriteria()
+                dto.getName(),
+                dto.getIssuingOrganization(),
+                dto.getCertificationType(),
+                dto.getPreparation(),
+                dto.getEligibility(),
+                dto.getExamStructure(),
+                dto.getPassingCriteria()
         );
     }
 }

--- a/src/main/java/com/example/masterplanbbe/domain/spec/response/UpdateSpecResponse.java
+++ b/src/main/java/com/example/masterplanbbe/domain/spec/response/UpdateSpecResponse.java
@@ -15,8 +15,7 @@ public record UpdateSpecResponse(
         Category category,
         CertificationType certificationType,
         Double difficulty,
-        Integer participantCount,
-        List<ExamDetail> examDetails
+        Integer participantCount
 ) {
     public UpdateSpecResponse(Spec spec) {
         this(
@@ -26,8 +25,7 @@ public record UpdateSpecResponse(
                 spec.getCategory(),
                 spec.getCertificationType(),
                 spec.getDifficulty(),
-                spec.getParticipantCount(),
-                spec.getExamDetails()
+                spec.getParticipantCount()
         );
     }
 }

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/SpecFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/SpecFixture.java
@@ -10,9 +10,11 @@ import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.example.masterplanbbe.domain.spec.request.SpecCreateRequest;
 import com.example.masterplanbbe.domain.spec.request.SpecUpdateRequest;
 import com.example.masterplanbbe.utils.TestUtils;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static com.example.masterplanbbe.domain.exam.enums.Category.*;
 import static com.example.masterplanbbe.domain.exam.enums.CertificationType.*;
@@ -67,6 +69,13 @@ public class SpecFixture {
 
     public static Spec createExistingSpecFrom(Long specId) {
         return TestUtils.createExistingEntity(SpecFixture::createSpec, specId);
+    }
+
+    public static Spec createUpdatedSpec(Supplier<Spec> specSupplier, Double difficulty) {
+        return TestUtils.withSetup(
+                specSupplier,
+                spec -> ReflectionTestUtils.setField(spec, "difficulty", difficulty)
+        );
     }
 
     public static SpecCreateRequest createSpecCreateRequest() {

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/SpecFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/SpecFixture.java
@@ -1,13 +1,16 @@
 package com.example.masterplanbbe.domain.fixture;
 
+import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.entity.ExamDetail;
 import com.example.masterplanbbe.domain.exam.entity.Subject;
 import com.example.masterplanbbe.domain.exam.request.SubjectCreateRequest;
+import com.example.masterplanbbe.domain.spec.dto.SpecWithDetailsDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.example.masterplanbbe.domain.spec.request.SpecCreateRequest;
 import com.example.masterplanbbe.domain.spec.request.SpecUpdateRequest;
 import com.example.masterplanbbe.utils.TestUtils;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static com.example.masterplanbbe.domain.exam.enums.Category.*;
@@ -40,6 +43,19 @@ public class SpecFixture {
                 .name("RC")
                 .examDetail(examDetail)
                 .build();
+
+        LocalDate now = LocalDate.now();
+
+        Exam exam = Exam.builder()
+                .examDetail(examDetail)
+                .name(now.getYear() + "년 1회")
+                .applyStartDate(now.minusDays(5L))
+                .applyEndDate(now.plusDays(3L))
+                .examStartDate(now.plusDays(10L))
+                .participantCount(0)
+                .build();
+
+        spec.specifyLatestExam(exam);
 
         return spec;
     }
@@ -78,6 +94,19 @@ public class SpecFixture {
                 3.2,
                 120,
                 examDetails
+        );
+    }
+
+    public static SpecWithDetailsDto createSpecWithDetailsDto(Spec spec) {
+        return new SpecWithDetailsDto(
+                spec.getName(),
+                spec.getIssuingOrganization(),
+                spec.getCertificationType(),
+                false,
+                spec.getLatestExam().getExamDetail().getPreparation(),
+                spec.getLatestExam().getExamDetail().getEligibility(),
+                spec.getLatestExam().getExamDetail().getExamStructure(),
+                spec.getLatestExam().getExamDetail().getPassingCriteria()
         );
     }
 }

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/SpecFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/SpecFixture.java
@@ -4,6 +4,7 @@ import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.entity.ExamDetail;
 import com.example.masterplanbbe.domain.exam.entity.Subject;
 import com.example.masterplanbbe.domain.exam.request.SubjectCreateRequest;
+import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.dto.SpecWithDetailsDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.example.masterplanbbe.domain.spec.request.SpecCreateRequest;
@@ -94,6 +95,19 @@ public class SpecFixture {
                 3.2,
                 120,
                 examDetails
+        );
+    }
+
+    public static SpecItemCardDto createSpecItemCardDto(Spec spec, boolean isBookmarked) {
+        return new SpecItemCardDto(
+                spec.getName(),
+                spec.getCategory(),
+                spec.getDifficulty(),
+                spec.getParticipantCount(),
+                spec.getLatestExam().getApplyStartDate(),
+                spec.getLatestExam().getApplyEndDate(),
+                spec.getLatestExam().getExamStartDate(),
+                isBookmarked
         );
     }
 

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/SpecFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/SpecFixture.java
@@ -3,6 +3,7 @@ package com.example.masterplanbbe.domain.fixture;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.entity.ExamDetail;
 import com.example.masterplanbbe.domain.exam.entity.Subject;
+import com.example.masterplanbbe.domain.exam.enums.CertificationType;
 import com.example.masterplanbbe.domain.exam.request.SubjectCreateRequest;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.dto.SpecWithDetailsDto;
@@ -71,10 +72,10 @@ public class SpecFixture {
         return TestUtils.createExistingEntity(SpecFixture::createSpec, specId);
     }
 
-    public static Spec createUpdatedSpec(Supplier<Spec> specSupplier, Double difficulty) {
+    public static Spec createUpdatedSpec(Supplier<Spec> specSupplier, CertificationType certificationType) {
         return TestUtils.withSetup(
                 specSupplier,
-                spec -> ReflectionTestUtils.setField(spec, "difficulty", difficulty)
+                spec -> ReflectionTestUtils.setField(spec, "certificationType", NATIONAL_CERTIFIED)
         );
     }
 
@@ -95,13 +96,13 @@ public class SpecFixture {
         );
     }
 
-    public static SpecUpdateRequest createSpecUpdateRequest(Spec spec, Double difficulty) {
+    public static SpecUpdateRequest createSpecUpdateRequest(Spec spec, CertificationType certificationType) {
         return new SpecUpdateRequest(
                 spec.getName(),
                 spec.getCategory(),
-                spec.getCertificationType(),
+                certificationType,
                 spec.getIssuingOrganization(),
-                difficulty,
+                spec.getDifficulty(),
                 spec.getParticipantCount()
         );
     }

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/SpecFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/SpecFixture.java
@@ -86,15 +86,14 @@ public class SpecFixture {
         );
     }
 
-    public static SpecUpdateRequest createSpecUpdateRequest(List<ExamDetail> examDetails) {
+    public static SpecUpdateRequest createSpecUpdateRequest(Spec spec, Double difficulty) {
         return new SpecUpdateRequest(
-                "TOEIC",
-                LANGUAGE,
-                ETC,
-                "ETS",
-                3.2,
-                120,
-                examDetails
+                spec.getName(),
+                spec.getCategory(),
+                spec.getCertificationType(),
+                spec.getIssuingOrganization(),
+                difficulty,
+                spec.getParticipantCount()
         );
     }
 

--- a/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
@@ -182,8 +182,9 @@ public class SpecControllerTest {
         Spec spec = createExistingSpecFrom(specId);
         SpecUpdateRequest request = createSpecUpdateRequest(spec, 4.0);
         given(specService.update(specId, request)).willReturn(new UpdateSpecResponse(
-                withSetup(() -> createExistingSpecFrom(specId), entity -> setField(entity, "difficulty", 4.0))
-        ));
+                        createUpdatedSpec(() -> spec, 4.0)
+                )
+        );
 
         ResultActions resultActions = mockMvc.perform(patch("/api/v1/specs/{specId}", specId)
                 .contentType(APPLICATION_JSON)

--- a/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
@@ -1,0 +1,4 @@
+package com.example.masterplanbbe.domain.spec.controller;
+
+public class SpecControllerTest {
+}

--- a/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -152,7 +153,21 @@ public class SpecControllerTest {
 
     @Test
     @DisplayName("관리자는 스펙을 삭제한다")
-    void deleteSpec() {
+    void deleteSpec() throws Exception {
+        Long specId = 1L;
+        willDoNothing().given(specService).delete(specId);
 
+        ResultActions resultActions = mockMvc.perform(delete("/api/v1/specs/{specId}", specId)
+                .characterEncoding(UTF_8));
+
+        resultActions.andExpectAll(status().isOk(), content().contentType(APPLICATION_JSON))
+                .andDo(print())
+                .andDo(mvcResult -> {
+                    String responseContent = mvcResult.getResponse().getContentAsString(UTF_8);
+                    ApiResponse<Void> response = objectMapper.readValue(responseContent, new TypeReference<>() {
+                    });
+                    assertThat(response).isNotNull();
+                    assertThat(response.getMessage()).isEqualTo("스펙 삭제 성공");
+                });
     }
 }

--- a/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
@@ -1,4 +1,48 @@
 package com.example.masterplanbbe.domain.spec.controller;
 
+import com.example.masterplanbbe.common.page.CustomPage;
+import com.example.masterplanbbe.common.request.CustomPageRequest;
+import com.example.masterplanbbe.domain.member.entity.Member;
+import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
+import com.example.masterplanbbe.domain.spec.enums.SpecSortOption;
+import com.example.masterplanbbe.domain.spec.service.SpecService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
+
+@ExtendWith(MockitoExtension.class)
 public class SpecControllerTest {
+    @InjectMocks
+    private SpecController specController;
+
+    @Mock
+    private SpecService specService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(specController).build();
+    }
+
+    @Test
+    @DisplayName("사용자는 스펙 목록을 조회한다.")
+    void getSpecList() {
+        Member member = createMember();
+        CustomPageRequest<SpecSortOption> request = new CustomPageRequest<>(0, 25, null, false);
+        CustomPage<SpecItemCardDto> mockedPage = createMockedSpecItemCardPage();
+    }
+
+    private CustomPage<SpecItemCardDto> createMockedSpecItemCardPage() {
+
+        return null;
+    }
 }

--- a/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
@@ -4,6 +4,7 @@ import com.example.masterplanbbe.common.page.CustomPage;
 import com.example.masterplanbbe.common.request.CustomPageRequest;
 import com.example.masterplanbbe.common.response.ApiResponse;
 import com.example.masterplanbbe.common.response.PageResponse;
+import com.example.masterplanbbe.domain.exam.enums.CertificationType;
 import com.example.masterplanbbe.domain.member.entity.Member;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
@@ -32,6 +33,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.List;
 
+import static com.example.masterplanbbe.domain.exam.enums.CertificationType.*;
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 import static com.example.masterplanbbe.domain.fixture.SpecFixture.*;
 import static com.example.masterplanbbe.utils.TestUtils.*;
@@ -180,9 +182,9 @@ public class SpecControllerTest {
     void updateSpec() throws Exception {
         Long specId = 1L;
         Spec spec = createExistingSpecFrom(specId);
-        SpecUpdateRequest request = createSpecUpdateRequest(spec, 4.0);
+        SpecUpdateRequest request = createSpecUpdateRequest(spec, NATIONAL_CERTIFIED);
         given(specService.update(specId, request)).willReturn(new UpdateSpecResponse(
-                        createUpdatedSpec(() -> spec, 4.0)
+                        createUpdatedSpec(() -> spec, NATIONAL_CERTIFIED)
                 )
         );
 

--- a/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
@@ -2,25 +2,42 @@ package com.example.masterplanbbe.domain.spec.controller;
 
 import com.example.masterplanbbe.common.page.CustomPage;
 import com.example.masterplanbbe.common.request.CustomPageRequest;
+import com.example.masterplanbbe.common.response.ApiResponse;
+import com.example.masterplanbbe.common.response.PageResponse;
 import com.example.masterplanbbe.domain.member.entity.Member;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.example.masterplanbbe.domain.spec.enums.SpecSortOption;
 import com.example.masterplanbbe.domain.spec.service.SpecService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 import static com.example.masterplanbbe.domain.fixture.SpecFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 public class SpecControllerTest {
@@ -32,6 +49,8 @@ public class SpecControllerTest {
 
     private MockMvc mockMvc;
 
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
     @BeforeEach
     public void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(specController).build();
@@ -39,10 +58,37 @@ public class SpecControllerTest {
 
     @Test
     @DisplayName("사용자는 스펙을 조회하고 북마크 여부를 확인한다.")
-    void retrieve_spec_and_check_bookmark_status() {
-        Member member = createMember();
+    void retrieve_spec_and_check_bookmark_status() throws Exception {
+        Member member = createExistingMember();
         CustomPageRequest<SpecSortOption> request = new CustomPageRequest<>(0, 25, null, false);
         CustomPage<SpecItemCardDto> mockedPage = createMockedSpecItemCardPage();
+        given(specService.getAllSpec(request, member.getId())).willReturn(new PageResponse<>(mockedPage));
+
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/specs")
+                .param("page", "0")
+                .param("size", "25")
+                .param("sortOption", (String) null)
+                .param("isAsc", "false")
+                .param("memberId", member.getId().toString())
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(StandardCharsets.UTF_8)
+                .accept(MediaType.APPLICATION_JSON));
+
+        resultActions.andExpectAll(status().isOk(), content().contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(mvcResult -> {
+                    String responseContent = mvcResult.getResponse().getContentAsString();
+                    ApiResponse<PageResponse<SpecItemCardDto>> response = objectMapper.readValue(responseContent, new TypeReference<>() {
+                    });
+                    PageResponse<SpecItemCardDto> data = response.getData();
+                    assertThat(data).isNotNull();
+                    assertThat(data.content()).isNotNull();
+                    assertAll(
+                            () -> assertThat(data.content().size()).isEqualTo(2),
+                            () -> assertThat(data.content()).usingRecursiveFieldByFieldElementComparator()
+                                    .containsExactlyInAnyOrderElementsOf(mockedPage.content())
+                    );
+                });
     }
 
     private CustomPage<SpecItemCardDto> createMockedSpecItemCardPage() {

--- a/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
@@ -4,6 +4,7 @@ import com.example.masterplanbbe.common.page.CustomPage;
 import com.example.masterplanbbe.common.request.CustomPageRequest;
 import com.example.masterplanbbe.domain.member.entity.Member;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
+import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.example.masterplanbbe.domain.spec.enums.SpecSortOption;
 import com.example.masterplanbbe.domain.spec.service.SpecService;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,7 +17,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.List;
+
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
+import static com.example.masterplanbbe.domain.fixture.SpecFixture.*;
 
 @ExtendWith(MockitoExtension.class)
 public class SpecControllerTest {
@@ -42,7 +46,37 @@ public class SpecControllerTest {
     }
 
     private CustomPage<SpecItemCardDto> createMockedSpecItemCardPage() {
+        Spec spec1 = createExistingSpecFrom(1L);
+        Spec spec2 = createExistingSpecFrom(2L);
+        List<SpecItemCardDto> specItemCardDtoList = List.of(
+                createSpecItemCardDto(spec1, false),
+                createSpecItemCardDto(spec2, false)
+        );
 
-        return null;
+        return new CustomPage<>(0, 25, specItemCardDtoList.size(), specItemCardDtoList);
+    }
+
+    @Test
+    @DisplayName("사용자는 스펙을 상세 조회한다")
+    void getSpecDetail() {
+
+    }
+
+    @Test
+    @DisplayName("관리자는 스펙을 추가한다")
+    void addSpec() {
+
+    }
+
+    @Test
+    @DisplayName("관리자는 스펙을 수정한다")
+    void updateSpec() {
+
+    }
+
+    @Test
+    @DisplayName("관리자는 스펙을 삭제한다")
+    void deleteSpec() {
+
     }
 }

--- a/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
@@ -8,9 +8,13 @@ import com.example.masterplanbbe.domain.member.entity.Member;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.example.masterplanbbe.domain.spec.enums.SpecSortOption;
+import com.example.masterplanbbe.domain.spec.request.SpecCreateRequest;
+import com.example.masterplanbbe.domain.spec.request.SpecUpdateRequest;
+import com.example.masterplanbbe.domain.spec.response.CreateSpecResponse;
 import com.example.masterplanbbe.domain.spec.response.ReadSpecResponse;
+import com.example.masterplanbbe.domain.spec.response.UpdateSpecResponse;
 import com.example.masterplanbbe.domain.spec.service.SpecService;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.example.masterplanbbe.utils.TestUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -18,27 +22,26 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 import static com.example.masterplanbbe.domain.fixture.SpecFixture.*;
+import static com.example.masterplanbbe.utils.TestUtils.*;
 import static java.nio.charset.StandardCharsets.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.http.MediaType.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.util.ReflectionTestUtils.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -141,14 +144,69 @@ public class SpecControllerTest {
 
     @Test
     @DisplayName("관리자는 스펙을 추가한다")
-    void addSpec() {
+    void addSpec() throws Exception {
+        SpecCreateRequest request = createSpecCreateRequest();
+        CreateSpecResponse mockedResult = new CreateSpecResponse(createExistingSpec());
+        given(specService.create(request)).willReturn(mockedResult);
 
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/specs")
+                .contentType(APPLICATION_JSON)
+                .characterEncoding(UTF_8)
+                .content(objectMapper.writeValueAsString(request))
+                .accept(APPLICATION_JSON));
+
+        resultActions.andExpectAll(status().isOk(), content().contentType(APPLICATION_JSON))
+                .andDo(print())
+                .andDo(mvcResult -> {
+                    String responseContent = mvcResult.getResponse().getContentAsString(UTF_8);
+                    ApiResponse<CreateSpecResponse> response = objectMapper.readValue(responseContent, new TypeReference<>() {
+                    });
+                    CreateSpecResponse data = response.getData();
+                    assertThat(data).isNotNull();
+                    assertAll(
+                            () -> assertThat(data.name()).isEqualTo(request.name()),
+                            () -> assertThat(data.issuingOrganization()).isEqualTo(request.issuingOrganization()),
+                            () -> assertThat(data.certificationType()).isEqualTo(request.certificationType()),
+                            () -> assertThat(data.preparation()).isEqualTo(request.preparation()),
+                            () -> assertThat(data.eligibility()).isEqualTo(request.eligibility()),
+                            () -> assertThat(data.examStructure()).isEqualTo(request.examStructure()),
+                            () -> assertThat(data.passingCriteria()).isEqualTo(request.passingCriteria())
+                    );
+                });
     }
 
     @Test
     @DisplayName("관리자는 스펙을 수정한다")
-    void updateSpec() {
+    void updateSpec() throws Exception {
+        Long specId = 1L;
+        Spec spec = createExistingSpecFrom(specId);
+        SpecUpdateRequest request = createSpecUpdateRequest(spec, 4.0);
+        given(specService.update(specId, request)).willReturn(new UpdateSpecResponse(
+                withSetup(() -> createExistingSpecFrom(specId), entity -> setField(entity, "difficulty", 4.0))
+        ));
 
+        ResultActions resultActions = mockMvc.perform(patch("/api/v1/specs/{specId}", specId)
+                .contentType(APPLICATION_JSON)
+                .characterEncoding(UTF_8)
+                .content(objectMapper.writeValueAsString(request))
+                .accept(APPLICATION_JSON));
+
+        resultActions.andExpectAll(status().isOk(), content().contentType(APPLICATION_JSON))
+                .andDo(print())
+                .andDo(mvcResult -> {
+                    String responseContent = mvcResult.getResponse().getContentAsString(UTF_8);
+                    ApiResponse<UpdateSpecResponse> response = objectMapper.readValue(responseContent, new TypeReference<>() {
+                    });
+                    UpdateSpecResponse data = response.getData();
+                    assertThat(data).isNotNull();
+                    assertAll(
+                            () -> assertThat(data.name()).isEqualTo(request.name()),
+                            () -> assertThat(data.issuingOrganization()).isEqualTo(request.issuingOrganization()),
+                            () -> assertThat(data.certificationType()).isEqualTo(request.certificationType()),
+                            () -> assertThat(data.difficulty()).isEqualTo(request.difficulty()),
+                            () -> assertThat(data.participantCount()).isEqualTo(request.participantCount())
+                    );
+                });
     }
 
     @Test

--- a/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
@@ -8,6 +8,7 @@ import com.example.masterplanbbe.domain.member.entity.Member;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.example.masterplanbbe.domain.spec.enums.SpecSortOption;
+import com.example.masterplanbbe.domain.spec.response.ReadSpecResponse;
 import com.example.masterplanbbe.domain.spec.service.SpecService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -31,9 +32,11 @@ import java.util.List;
 
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 import static com.example.masterplanbbe.domain.fixture.SpecFixture.*;
+import static java.nio.charset.StandardCharsets.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -70,14 +73,14 @@ public class SpecControllerTest {
                 .param("sortOption", (String) null)
                 .param("isAsc", "false")
                 .param("memberId", member.getId().toString())
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding(StandardCharsets.UTF_8)
-                .accept(MediaType.APPLICATION_JSON));
+                .contentType(APPLICATION_JSON)
+                .characterEncoding(UTF_8)
+                .accept(APPLICATION_JSON));
 
-        resultActions.andExpectAll(status().isOk(), content().contentType(MediaType.APPLICATION_JSON))
+        resultActions.andExpectAll(status().isOk(), content().contentType(APPLICATION_JSON))
                 .andDo(print())
                 .andDo(mvcResult -> {
-                    String responseContent = mvcResult.getResponse().getContentAsString();
+                    String responseContent = mvcResult.getResponse().getContentAsString(UTF_8);
                     ApiResponse<PageResponse<SpecItemCardDto>> response = objectMapper.readValue(responseContent, new TypeReference<>() {
                     });
                     PageResponse<SpecItemCardDto> data = response.getData();
@@ -104,8 +107,35 @@ public class SpecControllerTest {
 
     @Test
     @DisplayName("사용자는 스펙을 상세 조회한다")
-    void getSpecDetail() {
+    void getSpecDetail() throws Exception {
+        Member member = createExistingMember();
+        Long specId = 1L;
+        ReadSpecResponse mockedResult = new ReadSpecResponse(createSpecWithDetailsDto(createExistingSpecFrom(specId)));
+        given(specService.getSpec(specId)).willReturn(mockedResult);
 
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/specs/{specId}", specId)
+                .contentType(APPLICATION_JSON)
+                .characterEncoding(UTF_8)
+                .accept(APPLICATION_JSON));
+
+        resultActions.andExpectAll(status().isOk(), content().contentType(APPLICATION_JSON))
+                .andDo(print())
+                .andDo(mvcResult -> {
+                    String responseContent = mvcResult.getResponse().getContentAsString(UTF_8);
+                    ApiResponse<ReadSpecResponse> response = objectMapper.readValue(responseContent, new TypeReference<>() {
+                    });
+                    ReadSpecResponse data = response.getData();
+                    assertThat(data).isNotNull();
+                    assertAll(
+                            () -> assertThat(data.name()).isEqualTo(mockedResult.name()),
+                            () -> assertThat(data.issuingOrganization()).isEqualTo(mockedResult.issuingOrganization()),
+                            () -> assertThat(data.certificationType()).isEqualTo(mockedResult.certificationType()),
+                            () -> assertThat(data.preparation()).isEqualTo(mockedResult.preparation()),
+                            () -> assertThat(data.eligibility()).isEqualTo(mockedResult.eligibility()),
+                            () -> assertThat(data.examStructure()).isEqualTo(mockedResult.examStructure()),
+                            () -> assertThat(data.passingCriteria()).isEqualTo(mockedResult.passingCriteria())
+                    );
+                });
     }
 
     @Test

--- a/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/controller/SpecControllerTest.java
@@ -38,8 +38,8 @@ public class SpecControllerTest {
     }
 
     @Test
-    @DisplayName("사용자는 스펙 목록을 조회한다.")
-    void getSpecList() {
+    @DisplayName("사용자는 스펙을 조회하고 북마크 여부를 확인한다.")
+    void retrieve_spec_and_check_bookmark_status() {
         Member member = createMember();
         CustomPageRequest<SpecSortOption> request = new CustomPageRequest<>(0, 25, null, false);
         CustomPage<SpecItemCardDto> mockedPage = createMockedSpecItemCardPage();

--- a/src/test/java/com/example/masterplanbbe/domain/spec/entity/SpecTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/entity/SpecTest.java
@@ -4,6 +4,7 @@ import com.example.masterplanbbe.domain.spec.request.SpecUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static com.example.masterplanbbe.domain.exam.enums.CertificationType.*;
 import static com.example.masterplanbbe.domain.fixture.SpecFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -14,7 +15,7 @@ public class SpecTest {
     @DisplayName("update 메서드는 스펙 엔티티의 필드를 수정한다.")
     void update_updates_spec_fields() {
         Spec spec = createExistingSpec();
-        SpecUpdateRequest request = createSpecUpdateRequest(spec, 4.0);
+        SpecUpdateRequest request = createSpecUpdateRequest(spec, NATIONAL_CERTIFIED);
 
         spec.update(
                 request.name(),

--- a/src/test/java/com/example/masterplanbbe/domain/spec/entity/SpecTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/entity/SpecTest.java
@@ -14,7 +14,7 @@ public class SpecTest {
     @DisplayName("update 메서드는 스펙 엔티티의 필드를 수정한다.")
     void update_updates_spec_fields() {
         Spec spec = createExistingSpec();
-        SpecUpdateRequest request = createSpecUpdateRequest(spec.getExamDetails());
+        SpecUpdateRequest request = createSpecUpdateRequest(spec, 4.0);
 
         spec.update(
                 request.name(),
@@ -22,8 +22,7 @@ public class SpecTest {
                 request.category(),
                 request.certificationType(),
                 request.difficulty(),
-                request.participantCount(),
-                request.examDetails()
+                request.participantCount()
         );
 
         assertAll(
@@ -32,8 +31,7 @@ public class SpecTest {
                 () -> assertThat(spec.getCategory()).isEqualTo(request.category()),
                 () -> assertThat(spec.getCertificationType()).isEqualTo(request.certificationType()),
                 () -> assertThat(spec.getDifficulty()).isEqualTo(request.difficulty()),
-                () -> assertThat(spec.getParticipantCount()).isEqualTo(request.participantCount()),
-                () -> assertThat(spec.getExamDetails()).isEqualTo(request.examDetails())
+                () -> assertThat(spec.getParticipantCount()).isEqualTo(request.participantCount())
         );
     }
 }

--- a/src/test/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryPortTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryPortTest.java
@@ -46,7 +46,7 @@ public class SpecRepositoryPortTest {
     }
 
     @Test
-    @DisplayName("사용자는 스펙을 조회하고 북마크 여부를 확인할 수 있다.")
+    @DisplayName("사용자는 스펙을 조회하고 북마크 여부를 확인한다.")
     void retrieve_spec_and_check_bookmark_status() {
         Member member = memberRepository.save(createMember());
         Spec spec1 = createSpec();

--- a/src/test/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryPortTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryPortTest.java
@@ -17,8 +17,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
@@ -42,8 +40,8 @@ public class SpecRepositoryPortTest {
     @BeforeEach
     void setUp() {
         specBookmarkRepository.deleteAll();
-        examRepository.deleteAll();
         specRepositoryPort.deleteAll();
+        examRepository.deleteAll();
         memberRepository.deleteAll();
     }
 
@@ -78,14 +76,14 @@ public class SpecRepositoryPortTest {
 
         assertThat(result).isNotNull();
         assertAll(
-                () -> assertThat(result.name()).isEqualTo(spec.getName()),
-                () -> assertThat(result.issuingOrganization()).isEqualTo(spec.getIssuingOrganization()),
-                () -> assertThat(result.certificationType()).isEqualTo(spec.getCertificationType()),
-                () -> assertThat(result.preparation()).isEqualTo(spec.getExamDetails().get(0).getPreparation()),
-                () -> assertThat(result.examStructure()).isEqualTo(spec.getExamDetails().get(0).getExamStructure()),
-                () -> assertThat(result.eligibility()).isEqualTo(spec.getExamDetails().get(0).getEligibility()),
-                () -> assertThat(result.passingCriteria()).isEqualTo(spec.getExamDetails().get(0).getPassingCriteria()),
-                () -> assertThat(result.isBookmarked()).isFalse()
+                () -> assertThat(result.getName()).isEqualTo(spec.getName()),
+                () -> assertThat(result.getIssuingOrganization()).isEqualTo(spec.getIssuingOrganization()),
+                () -> assertThat(result.getCertificationType()).isEqualTo(spec.getCertificationType()),
+                () -> assertThat(result.getPreparation()).isEqualTo(spec.getExamDetails().get(0).getPreparation()),
+                () -> assertThat(result.getExamStructure()).isEqualTo(spec.getExamDetails().get(0).getExamStructure()),
+                () -> assertThat(result.getEligibility()).isEqualTo(spec.getExamDetails().get(0).getEligibility()),
+                () -> assertThat(result.getPassingCriteria()).isEqualTo(spec.getExamDetails().get(0).getPassingCriteria()),
+                () -> assertThat(result.getIsBookmarked()).isFalse()
         );
     }
 

--- a/src/test/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryPortTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryPortTest.java
@@ -60,10 +60,10 @@ public class SpecRepositoryPortTest {
 
         assertThat(result.content().size()).isEqualTo(2);
         assertAll(
-                () -> assertThat(result.content().get(0).name()).isEqualTo(spec1.getName()),
-                () -> assertThat(result.content().get(1).name()).isEqualTo(spec2.getName()),
-                () -> assertThat(result.content().get(0).isBookmarked()).isTrue(),
-                () -> assertThat(result.content().get(1).isBookmarked()).isFalse()
+                () -> assertThat(result.content().get(0).getName()).isEqualTo(spec1.getName()),
+                () -> assertThat(result.content().get(1).getName()).isEqualTo(spec2.getName()),
+                () -> assertThat(result.content().get(0).getIsBookmarked()).isTrue(),
+                () -> assertThat(result.content().get(1).getIsBookmarked()).isFalse()
         );
     }
 

--- a/src/test/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryPortTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/repository/SpecRepositoryPortTest.java
@@ -79,10 +79,10 @@ public class SpecRepositoryPortTest {
                 () -> assertThat(result.getName()).isEqualTo(spec.getName()),
                 () -> assertThat(result.getIssuingOrganization()).isEqualTo(spec.getIssuingOrganization()),
                 () -> assertThat(result.getCertificationType()).isEqualTo(spec.getCertificationType()),
-                () -> assertThat(result.getPreparation()).isEqualTo(spec.getExamDetails().get(0).getPreparation()),
-                () -> assertThat(result.getExamStructure()).isEqualTo(spec.getExamDetails().get(0).getExamStructure()),
-                () -> assertThat(result.getEligibility()).isEqualTo(spec.getExamDetails().get(0).getEligibility()),
-                () -> assertThat(result.getPassingCriteria()).isEqualTo(spec.getExamDetails().get(0).getPassingCriteria()),
+                () -> assertThat(result.getPreparation()).isEqualTo(spec.getLatestExam().getExamDetail().getPreparation()),
+                () -> assertThat(result.getExamStructure()).isEqualTo(spec.getLatestExam().getExamDetail().getExamStructure()),
+                () -> assertThat(result.getEligibility()).isEqualTo(spec.getLatestExam().getExamDetail().getEligibility()),
+                () -> assertThat(result.getPassingCriteria()).isEqualTo(spec.getLatestExam().getExamDetail().getPassingCriteria()),
                 () -> assertThat(result.getIsBookmarked()).isFalse()
         );
     }

--- a/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
@@ -3,8 +3,6 @@ package com.example.masterplanbbe.domain.spec.service;
 import com.example.masterplanbbe.common.page.CustomPage;
 import com.example.masterplanbbe.common.request.CustomPageRequest;
 import com.example.masterplanbbe.common.response.PageResponse;
-import com.example.masterplanbbe.domain.fixture.MemberFixture;
-import com.example.masterplanbbe.domain.fixture.SpecFixture;
 import com.example.masterplanbbe.domain.member.entity.Member;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.dto.SpecWithDetailsDto;
@@ -18,28 +16,28 @@ import com.example.masterplanbbe.domain.spec.response.ReadSpecResponse;
 import com.example.masterplanbbe.domain.spec.response.UpdateSpecResponse;
 import com.example.masterplanbbe.domain.specBookmark.entity.SpecBookmark;
 import com.example.masterplanbbe.utils.TestUtils;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 import static com.example.masterplanbbe.domain.fixture.SpecBookmarkFixture.createSpecBookmark;
 import static com.example.masterplanbbe.domain.fixture.SpecFixture.*;
+import static com.example.masterplanbbe.utils.TestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("스펙 서비스 테스트")
@@ -135,8 +133,10 @@ public class SpecServiceTest {
     void update_spec() {
         Long specId = 1L;
         Spec spec = createExistingSpecFrom(specId);
-        SpecUpdateRequest request = createSpecUpdateRequest(spec.getExamDetails());
-        given(specRepositoryPort.getById(any(Long.class))).willReturn(spec);
+        SpecUpdateRequest request = createSpecUpdateRequest(spec, 4.0);
+        given(specRepositoryPort.getById(any(Long.class))).willReturn(
+                withSetup(() -> createExistingSpecFrom(specId), entity -> setField(entity, "difficulty", 4.0))
+        );
 
         UpdateSpecResponse result = specService.update(specId, request);
 
@@ -148,8 +148,6 @@ public class SpecServiceTest {
                 () -> assertThat(result.difficulty()).isEqualTo(request.difficulty()),
                 () -> assertThat(result.participantCount()).isEqualTo(request.participantCount())
         );
-        assertThat(result.examDetails().size()).isEqualTo(request.examDetails().size());
-        assertThat(result.examDetails()).containsExactlyInAnyOrderElementsOf(request.examDetails());
     }
 
     @Test

--- a/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
@@ -69,8 +69,8 @@ public class SpecServiceTest {
         SpecBookmark specBookmark1 = createSpecBookmark(member, spec1);
 
         return new CustomPage<>(0, 25, 2, List.of(
-                new SpecItemCardDto(spec1, null, isBookmarkedBy(spec1, specBookmark1)),
-                new SpecItemCardDto(spec2, null, isBookmarkedBy(spec2, specBookmark1))
+                createSpecItemCardDto(spec1, isBookmarkedBy(spec1, specBookmark1)),
+                createSpecItemCardDto(spec2, isBookmarkedBy(spec2, specBookmark1))
         ));
     }
 
@@ -78,8 +78,8 @@ public class SpecServiceTest {
         assertThat(result).isNotNull();
         assertAll(
                 () -> assertThat(result.content().size()).isEqualTo(2),
-                () -> assertThat(result.content().get(0).isBookmarked()).isTrue(),
-                () -> assertThat(result.content().get(1).isBookmarked()).isFalse()
+                () -> assertThat(result.content().get(0).getIsBookmarked()).isTrue(),
+                () -> assertThat(result.content().get(1).getIsBookmarked()).isFalse()
         );
     }
 

--- a/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
@@ -19,25 +19,22 @@ import com.example.masterplanbbe.utils.TestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 
+import static com.example.masterplanbbe.domain.exam.enums.CertificationType.*;
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.*;
 import static com.example.masterplanbbe.domain.fixture.SpecBookmarkFixture.createSpecBookmark;
 import static com.example.masterplanbbe.domain.fixture.SpecFixture.*;
-import static com.example.masterplanbbe.utils.TestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.util.ReflectionTestUtils.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("스펙 서비스 테스트")
@@ -133,9 +130,9 @@ public class SpecServiceTest {
     void update_spec() {
         Long specId = 1L;
         Spec spec = createExistingSpecFrom(specId);
-        SpecUpdateRequest request = createSpecUpdateRequest(spec, 4.0);
+        SpecUpdateRequest request = createSpecUpdateRequest(spec, NATIONAL_CERTIFIED);
         given(specRepositoryPort.getById(any(Long.class))).willReturn(
-                createUpdatedSpec(() -> spec, 4.0)
+                createUpdatedSpec(() -> spec, NATIONAL_CERTIFIED)
         );
 
         UpdateSpecResponse result = specService.update(specId, request);

--- a/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
@@ -135,7 +135,7 @@ public class SpecServiceTest {
         Spec spec = createExistingSpecFrom(specId);
         SpecUpdateRequest request = createSpecUpdateRequest(spec, 4.0);
         given(specRepositoryPort.getById(any(Long.class))).willReturn(
-                withSetup(() -> createExistingSpecFrom(specId), entity -> setField(entity, "difficulty", 4.0))
+                createUpdatedSpec(() -> spec, 4.0)
         );
 
         UpdateSpecResponse result = specService.update(specId, request);

--- a/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
@@ -103,10 +103,10 @@ public class SpecServiceTest {
                 () -> assertThat(result.name()).isEqualTo(spec.getName()),
                 () -> assertThat(result.issuingOrganization()).isEqualTo(spec.getIssuingOrganization()),
                 () -> assertThat(result.certificationType()).isEqualTo(spec.getCertificationType()),
-                () -> assertThat(result.preparation()).isEqualTo(spec.getExamDetails().get(0).getPreparation()),
-                () -> assertThat(result.eligibility()).isEqualTo(spec.getExamDetails().get(0).getEligibility()),
-                () -> assertThat(result.examStructure()).isEqualTo(spec.getExamDetails().get(0).getExamStructure()),
-                () -> assertThat(result.passingCriteria()).isEqualTo(spec.getExamDetails().get(0).getPassingCriteria())
+                () -> assertThat(result.preparation()).isEqualTo(spec.getLatestExam().getExamDetail().getPreparation()),
+                () -> assertThat(result.eligibility()).isEqualTo(spec.getLatestExam().getExamDetail().getEligibility()),
+                () -> assertThat(result.examStructure()).isEqualTo(spec.getLatestExam().getExamDetail().getExamStructure()),
+                () -> assertThat(result.passingCriteria()).isEqualTo(spec.getLatestExam().getExamDetail().getPassingCriteria())
         );
     }
 
@@ -146,13 +146,10 @@ public class SpecServiceTest {
                 () -> assertThat(result.issuingOrganization()).isEqualTo(request.issuingOrganization()),
                 () -> assertThat(result.certificationType()).isEqualTo(request.certificationType()),
                 () -> assertThat(result.difficulty()).isEqualTo(request.difficulty()),
-                () -> assertThat(result.participantCount()).isEqualTo(request.participantCount()),
-                () -> assertThat(result.examDetails().size()).isEqualTo(request.examDetails().size()),
-                () -> assertThat(result.examDetails().get(0).getPreparation()).isEqualTo(request.examDetails().get(0).getPreparation()),
-                () -> assertThat(result.examDetails().get(0).getEligibility()).isEqualTo(request.examDetails().get(0).getEligibility()),
-                () -> assertThat(result.examDetails().get(0).getExamStructure()).isEqualTo(request.examDetails().get(0).getExamStructure()),
-                () -> assertThat(result.examDetails().get(0).getPassingCriteria()).isEqualTo(request.examDetails().get(0).getPassingCriteria())
+                () -> assertThat(result.participantCount()).isEqualTo(request.participantCount())
         );
+        assertThat(result.examDetails().size()).isEqualTo(request.examDetails().size());
+        assertThat(result.examDetails()).containsExactlyInAnyOrderElementsOf(request.examDetails());
     }
 
     @Test

--- a/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
@@ -51,7 +51,7 @@ public class SpecServiceTest {
 
     @Test
     @DisplayName("사용자는 스펙을 조회하고 북마크 여부를 확인한다.")
-    void get_spec_and_check_bookmark() {
+    void retrieve_spec_and_check_bookmark_status() {
         Member member = createMember();
         CustomPageRequest<SpecSortOption> request = new CustomPageRequest<>(0, 25, null, false);
         CustomPage<SpecItemCardDto> mocked = createMockedSpecItemCardPage(member);

--- a/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/spec/service/SpecServiceTest.java
@@ -4,6 +4,7 @@ import com.example.masterplanbbe.common.page.CustomPage;
 import com.example.masterplanbbe.common.request.CustomPageRequest;
 import com.example.masterplanbbe.common.response.PageResponse;
 import com.example.masterplanbbe.domain.fixture.MemberFixture;
+import com.example.masterplanbbe.domain.fixture.SpecFixture;
 import com.example.masterplanbbe.domain.member.entity.Member;
 import com.example.masterplanbbe.domain.spec.dto.SpecItemCardDto;
 import com.example.masterplanbbe.domain.spec.dto.SpecWithDetailsDto;
@@ -92,7 +93,7 @@ public class SpecServiceTest {
     void get_spec_detail() {
         Long specId = 1L;
         Spec spec = createExistingSpecFrom(specId);
-        SpecWithDetailsDto mocked = new SpecWithDetailsDto(spec, spec.getExamDetails().get(0), false);
+        SpecWithDetailsDto mocked = createSpecWithDetailsDto(spec);
         given(specRepositoryPort.getSpecWithDetails(spec.getId())).willReturn(mocked);
 
         ReadSpecResponse result = specService.getSpec(specId);

--- a/src/test/java/com/example/masterplanbbe/utils/TestUtils.java
+++ b/src/test/java/com/example/masterplanbbe/utils/TestUtils.java
@@ -32,7 +32,7 @@ public class TestUtils {
         ReflectionTestUtils.setField(entity, "id", id);
     }
 
-    private static <T> T withSetup(Supplier<T> supplier, Consumer<T> setup) {
+    public static <T> T withSetup(Supplier<T> supplier, Consumer<T> setup) {
         T instance = supplier.get();
         setup.accept(instance);
         return instance;


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

* 최근 시험 조회를 위한 외래키 필드를 만든 후,  테스트 등 관련 코드를 변경했습니다.

* 스펙 수정 메서드에서 ExamDetail 업데이트 책임을 제외했습니다.

* 직렬화를 위한 기본 생성자가 DTO에 누락돼있던 것을 수정했습니다.

* Get 매핑 메서드에 ModelAttribute 어노테이션 parameter를 두어서, 
CustomPageRequest 객체가 정상적으로 바인딩되게 수정했습니다.