### PR TITLE
Feat/exam:: 시험 누락 컨트롤러 테스트 모두 작성

### DIFF
--- a/src/main/java/com/example/masterplanbbe/domain/exam/entity/Exam.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/entity/Exam.java
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Exam extends FullAuditEntity {
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "exam_detail_id")
     private ExamDetail examDetail;
 

--- a/src/main/java/com/example/masterplanbbe/domain/exam/request/ExamCreateRequest.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/request/ExamCreateRequest.java
@@ -2,6 +2,7 @@ package com.example.masterplanbbe.domain.exam.request;
 
 import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.entity.ExamDetail;
+import jakarta.persistence.EntityManager;
 
 import java.time.LocalDate;
 
@@ -11,9 +12,10 @@ public record ExamCreateRequest(
         LocalDate applyStartDate,
         LocalDate applyEndDate,
         LocalDate examStartDate,
-        ExamDetail examDetail
+        Long examDetailId
 ) {
-    public Exam toEntity() {
+    public Exam toEntity(EntityManager entityManager) {
+        ExamDetail examDetail = entityManager.getReference(ExamDetail.class, examDetailId);
         return new Exam(
                 examDetail,
                 name,

--- a/src/main/java/com/example/masterplanbbe/domain/exam/service/ExamService.java
+++ b/src/main/java/com/example/masterplanbbe/domain/exam/service/ExamService.java
@@ -11,6 +11,7 @@ import com.example.masterplanbbe.domain.exam.request.ExamUpdateRequest;
 import com.example.masterplanbbe.domain.exam.response.CreateExamResponse;
 import com.example.masterplanbbe.domain.exam.response.ReadExamResponse;
 import com.example.masterplanbbe.domain.exam.response.UpdateExamResponse;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ExamService {
     private final ExamRepositoryPort examRepositoryPort;
+    private final EntityManager entityManager;
 
     public PageResponse<ExamItemCardDto> getAllExam(CustomPageRequest<ExamSortOption> request,
                                                     String email) {
@@ -31,7 +33,7 @@ public class ExamService {
 
     @Transactional
     public CreateExamResponse create(ExamCreateRequest request) {
-        return new CreateExamResponse(examRepositoryPort.save(request.toEntity()));
+        return new CreateExamResponse(examRepositoryPort.save(request.toEntity(entityManager)));
     }
 
     @Transactional

--- a/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
@@ -5,6 +5,7 @@ import com.example.masterplanbbe.common.request.CustomPageRequest;
 import com.example.masterplanbbe.common.response.ApiResponse;
 import com.example.masterplanbbe.common.response.PageResponse;
 import com.example.masterplanbbe.domain.exam.dto.ExamItemCardDto;
+import com.example.masterplanbbe.domain.exam.entity.ExamDetail;
 import com.example.masterplanbbe.domain.exam.enums.ExamSortOption;
 import com.example.masterplanbbe.domain.exam.request.ExamCreateRequest;
 import com.example.masterplanbbe.domain.exam.response.CreateExamResponse;
@@ -14,6 +15,7 @@ import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -32,10 +34,12 @@ import static com.example.masterplanbbe.domain.fixture.ExamFixture.*;
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.createExistingMember;
 import static com.example.masterplanbbe.domain.fixture.SecurityFixture.*;
 import static com.example.masterplanbbe.domain.fixture.SpecFixture.createExistingSpec;
+import static com.example.masterplanbbe.utils.TestUtils.*;
 import static java.nio.charset.StandardCharsets.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.http.MediaType.*;
@@ -48,8 +52,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class ExamControllerTest {
     @InjectMocks
     private ExamController examController;
+
     @Mock
     private ExamService examService;
+
+    @Mock
+    private EntityManager entityManager;
 
     private MockMvc mockMvc;
 
@@ -64,6 +72,8 @@ public class ExamControllerTest {
         mockMvc = MockMvcBuilders.standaloneSetup(examController).build();
         member = createExistingMember();
         spec = createExistingSpec();
+
+        given(entityManager.getReference(eq(ExamDetail.class), any(Long.class))).willReturn(spec.getExamDetails().get(0));
     }
 
     @Test
@@ -112,9 +122,8 @@ public class ExamControllerTest {
     @Test
     @DisplayName("관리자는 시험을 추가한다")
     void addExam() throws Exception {
-/*
-        ExamCreateRequest request = createExamCreateRequest(spec.getExamDetails().get(0));
-        CreateExamResponse mockedResult = new CreateExamResponse(createExistingExamOf(spec.getExamDetails().get(0), 1L));
+        ExamCreateRequest request = createExamCreateRequest(createExistingEntity(() -> spec.getExamDetails().get(0)));
+        CreateExamResponse mockedResult = new CreateExamResponse(createExistingEntity(() -> request.toEntity(entityManager), 1L));
         given(examService.create(any(ExamCreateRequest.class))).willReturn(mockedResult);
 
         ResultActions resultActions = mockMvc.perform(post("/api/v1/exams")
@@ -140,7 +149,6 @@ public class ExamControllerTest {
                             () -> assertThat(data.examStartDate()).isEqualTo(request.examStartDate())
                     );
                 });
-*/
     }
 
     @Test

--- a/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
@@ -156,7 +156,6 @@ public class ExamControllerTest {
         ));
     }
 
-    @Disabled
     @Test
     @DisplayName("관리자는 시험을 추가한다")
     void addExam() throws Exception {

--- a/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
@@ -11,6 +11,7 @@ import com.example.masterplanbbe.domain.exam.enums.ExamSortOption;
 import com.example.masterplanbbe.domain.exam.request.ExamCreateRequest;
 import com.example.masterplanbbe.domain.exam.request.ExamUpdateRequest;
 import com.example.masterplanbbe.domain.exam.response.CreateExamResponse;
+import com.example.masterplanbbe.domain.exam.response.ReadExamResponse;
 import com.example.masterplanbbe.domain.exam.response.UpdateExamResponse;
 import com.example.masterplanbbe.domain.exam.service.ExamService;
 import com.example.masterplanbbe.domain.member.entity.Member;
@@ -108,6 +109,41 @@ public class ExamControllerTest {
                             () -> assertThat(data.content().size()).isEqualTo(2),
                             () -> assertThat(data.content().stream().allMatch(ExamItemCardDto::isBookmarked)).isFalse(),
                             () -> assertThat(data.content()).containsExactlyInAnyOrderElementsOf(mocked.content())
+                    );
+                });
+    }
+
+    @Test
+    @DisplayName("사용자는 시험을 상세 조회한다.")
+    void retrieve_exam_detail() throws Exception {
+        Long examId = 1L;
+        Exam exam = createExistingExamOf(spec.getExamDetails().get(0), examId);
+        ReadExamResponse mocked = new ReadExamResponse(createExamWithDetailsDto(exam));
+        given(examService.getExam(any(Long.class), any(String.class))).willReturn(mocked);
+
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/exams/" + examId)
+                .contentType(APPLICATION_JSON)
+                .characterEncoding(UTF_8)
+                .accept(APPLICATION_JSON)
+                .principal(createMockPrincipal(member))
+        );
+
+        resultActions.andExpectAll(status().isOk(), content().contentType(APPLICATION_JSON_VALUE))
+                .andDo(print())
+                .andDo(mvcResult -> {
+                    String responseContent = mvcResult.getResponse().getContentAsString(UTF_8);
+                    ApiResponse<ReadExamResponse> response = objectMapper.readValue(responseContent, new TypeReference<>() {
+                    });
+                    ReadExamResponse data = response.getData();
+                    assertThat(data).isNotNull();
+                    assertAll(
+                            () -> assertThat(data.name()).isEqualTo(exam.getName()),
+                            () -> assertThat(data.issuingOrganization()).isEqualTo(exam.getExamDetail().getSpec().getIssuingOrganization()),
+                            () -> assertThat(data.certificationType()).isEqualTo(exam.getExamDetail().getSpec().getCertificationType()),
+                            () -> assertThat(data.preparation()).isEqualTo(exam.getExamDetail().getPreparation()),
+                            () -> assertThat(data.eligibility()).isEqualTo(exam.getExamDetail().getEligibility()),
+                            () -> assertThat(data.examStructure()).isEqualTo(exam.getExamDetail().getExamStructure()),
+                            () -> assertThat(data.passingCriteria()).isEqualTo(exam.getExamDetail().getPassingCriteria())
                     );
                 });
     }

--- a/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/controller/ExamControllerTest.java
@@ -5,10 +5,13 @@ import com.example.masterplanbbe.common.request.CustomPageRequest;
 import com.example.masterplanbbe.common.response.ApiResponse;
 import com.example.masterplanbbe.common.response.PageResponse;
 import com.example.masterplanbbe.domain.exam.dto.ExamItemCardDto;
+import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.entity.ExamDetail;
 import com.example.masterplanbbe.domain.exam.enums.ExamSortOption;
 import com.example.masterplanbbe.domain.exam.request.ExamCreateRequest;
+import com.example.masterplanbbe.domain.exam.request.ExamUpdateRequest;
 import com.example.masterplanbbe.domain.exam.response.CreateExamResponse;
+import com.example.masterplanbbe.domain.exam.response.UpdateExamResponse;
 import com.example.masterplanbbe.domain.exam.service.ExamService;
 import com.example.masterplanbbe.domain.member.entity.Member;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
@@ -73,7 +76,6 @@ public class ExamControllerTest {
         member = createExistingMember();
         spec = createExistingSpec();
 
-        given(entityManager.getReference(eq(ExamDetail.class), any(Long.class))).willReturn(spec.getExamDetails().get(0));
     }
 
     @Test
@@ -123,6 +125,7 @@ public class ExamControllerTest {
     @DisplayName("관리자는 시험을 추가한다")
     void addExam() throws Exception {
         ExamCreateRequest request = createExamCreateRequest(createExistingEntity(() -> spec.getExamDetails().get(0)));
+        given(entityManager.getReference(eq(ExamDetail.class), any(Long.class))).willReturn(spec.getExamDetails().get(0));
         CreateExamResponse mockedResult = new CreateExamResponse(createExistingEntity(() -> request.toEntity(entityManager), 1L));
         given(examService.create(any(ExamCreateRequest.class))).willReturn(mockedResult);
 
@@ -140,6 +143,42 @@ public class ExamControllerTest {
                     ApiResponse<CreateExamResponse> response = objectMapper.readValue(responseContent, new TypeReference<>() {
                     });
                     CreateExamResponse data = response.getData();
+                    assertThat(data).isNotNull();
+                    assertAll(
+                            () -> assertThat(data.name()).isEqualTo(request.name()),
+                            () -> assertThat(data.participantCount()).isEqualTo(request.participantCount()),
+                            () -> assertThat(data.applyStartDate()).isEqualTo(request.applyStartDate()),
+                            () -> assertThat(data.applyEndDate()).isEqualTo(request.applyEndDate()),
+                            () -> assertThat(data.examStartDate()).isEqualTo(request.examStartDate())
+                    );
+                });
+    }
+
+    @Test
+    @DisplayName("관리자는 시험을 수정한다")
+    void updateExam() throws Exception {
+        Long examId = 1L;
+        Exam exam = createExistingExamOf(spec.getExamDetails().get(0), examId);
+        ExamUpdateRequest request = createExamUpdateRequest(exam, "수정된 이름");
+        given(examService.update(any(Long.class), any(ExamUpdateRequest.class))).willReturn(new UpdateExamResponse(
+                        createUpdatedExam(() -> exam, request.name())
+                )
+        );
+
+        ResultActions resultActions = mockMvc.perform(patch("/api/v1/exams/" + examId)
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(APPLICATION_JSON)
+                .characterEncoding(UTF_8)
+                .accept(APPLICATION_JSON)
+        );
+
+        resultActions.andExpectAll(status().isOk(), content().contentType(APPLICATION_JSON))
+                .andDo(print())
+                .andDo(mvcResult -> {
+                    String responseContent = mvcResult.getResponse().getContentAsString(UTF_8);
+                    ApiResponse<UpdateExamResponse> response = objectMapper.readValue(responseContent, new TypeReference<>() {
+                    });
+                    UpdateExamResponse data = response.getData();
                     assertThat(data).isNotNull();
                     assertAll(
                             () -> assertThat(data.name()).isEqualTo(request.name()),

--- a/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
+++ b/src/test/java/com/example/masterplanbbe/domain/exam/service/ExamServiceTest.java
@@ -6,6 +6,7 @@ import com.example.masterplanbbe.common.response.PageResponse;
 import com.example.masterplanbbe.domain.exam.dto.ExamItemCardDto;
 import com.example.masterplanbbe.domain.exam.dto.ExamWithDetailsDto;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
+import com.example.masterplanbbe.domain.exam.entity.ExamDetail;
 import com.example.masterplanbbe.domain.exam.enums.ExamSortOption;
 import com.example.masterplanbbe.domain.exam.repository.ExamRepositoryPort;
 import com.example.masterplanbbe.domain.exam.request.ExamCreateRequest;
@@ -17,6 +18,7 @@ import com.example.masterplanbbe.domain.member.entity.Member;
 import com.example.masterplanbbe.domain.spec.entity.Spec;
 import com.example.masterplanbbe.domain.specBookmark.entity.SpecBookmark;
 import com.example.masterplanbbe.utils.TestUtils;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,9 +31,11 @@ import java.util.List;
 import static com.example.masterplanbbe.domain.fixture.ExamFixture.*;
 import static com.example.masterplanbbe.domain.fixture.MemberFixture.createExistingMember;
 import static com.example.masterplanbbe.domain.fixture.SpecFixture.createExistingSpec;
+import static com.example.masterplanbbe.utils.TestUtils.createExistingEntity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.times;
@@ -43,6 +47,8 @@ public class ExamServiceTest {
     private ExamService examService;
     @Mock
     private ExamRepositoryPort examRepositoryPort;
+    @Mock
+    private EntityManager entityManager;
 
     @Test
     @DisplayName("사용자는 시험을 조회하고 스펙 북마크 여부를 확인한다.")
@@ -61,7 +67,7 @@ public class ExamServiceTest {
 
     private CustomPage<ExamItemCardDto> createMockedExamItemCardPage(Spec spec,
                                                                      Member member) {
-        Exam exam1 = TestUtils.createExistingEntity(spec::getLatestExam, 1L);
+        Exam exam1 = createExistingEntity(spec::getLatestExam, 1L);
         Exam exam2 = createExistingExamOf(spec.getExamDetails().get(0), 2L);
         Exam exam3 = createExistingExamOf(spec.getExamDetails().get(0), 3L);
         SpecBookmark specBookmark = new SpecBookmark(member, spec);
@@ -107,7 +113,7 @@ public class ExamServiceTest {
 
     private ExamWithDetailsDto createMockedExamWithDetailsDto(Exam exam, Member member) {
         Spec spec = exam.getExamDetail().getSpec();
-        SpecBookmark specBookmark = TestUtils.createExistingEntity(() -> new SpecBookmark(member, spec), 1L);
+        SpecBookmark specBookmark = createExistingEntity(() -> new SpecBookmark(member, spec), 1L);
 
         return new ExamWithDetailsDto(
                 exam.getName(),
@@ -139,7 +145,8 @@ public class ExamServiceTest {
     @DisplayName("관리자는 시험을 추가한다.")
     void create_exam() {
         Spec spec = createExistingSpec();
-        ExamCreateRequest request = createExamCreateRequest(spec.getExamDetails().get(0));
+        ExamCreateRequest request = createExamCreateRequest(createExistingEntity(() -> spec.getExamDetails().get(0), 1L));
+        given(entityManager.getReference(eq(ExamDetail.class), any(Long.class))).willReturn(spec.getExamDetails().get(0));
         given(examRepositoryPort.save(any(Exam.class))).willAnswer(TestUtils::simulateSavingEntity);
 
         CreateExamResponse result = examService.create(request);

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/ExamFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/ExamFixture.java
@@ -42,9 +42,9 @@ public class ExamFixture {
         return new ExamUpdateRequest(
                 name,
                 exam.getParticipantCount(),
-                exam.getApplyStartDate().minusDays(1),
-                exam.getApplyEndDate().plusDays(1),
-                exam.getExamStartDate().minusDays(1)
+                exam.getApplyStartDate(),
+                exam.getApplyEndDate(),
+                exam.getExamStartDate()
         );
     }
 

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/ExamFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/ExamFixture.java
@@ -1,6 +1,7 @@
 package com.example.masterplanbbe.domain.fixture;
 
 import com.example.masterplanbbe.domain.exam.dto.ExamItemCardDto;
+import com.example.masterplanbbe.domain.exam.dto.ExamWithDetailsDto;
 import com.example.masterplanbbe.domain.exam.entity.Exam;
 import com.example.masterplanbbe.domain.exam.entity.ExamDetail;
 import com.example.masterplanbbe.domain.exam.request.ExamCreateRequest;
@@ -45,6 +46,19 @@ public class ExamFixture {
                 exam.getApplyStartDate(),
                 exam.getApplyEndDate(),
                 exam.getExamStartDate()
+        );
+    }
+
+    public static ExamWithDetailsDto createExamWithDetailsDto(Exam exam) {
+        return new ExamWithDetailsDto(
+                exam.getName(),
+                exam.getExamDetail().getSpec().getIssuingOrganization(),
+                exam.getExamDetail().getSpec().getCertificationType(),
+                false,
+                exam.getExamDetail().getPreparation(),
+                exam.getExamDetail().getEligibility(),
+                exam.getExamDetail().getExamStructure(),
+                exam.getExamDetail().getPassingCriteria()
         );
     }
 

--- a/src/test/java/com/example/masterplanbbe/domain/fixture/ExamFixture.java
+++ b/src/test/java/com/example/masterplanbbe/domain/fixture/ExamFixture.java
@@ -34,7 +34,7 @@ public class ExamFixture {
                 LocalDate.now().minusDays(7),
                 LocalDate.now().minusDays(3),
                 LocalDate.now().plusDays(2),
-                examDetail
+                examDetail.getId()
         );
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#78 

## 📝작업 내용

* Exam.ExamDetail의 fetchType을 LAZY로 설정했습니다.

* ExamCreateRequest에서 ExamDetail 필드를 직접 가지지 않고, 
id로부터 JPA 프록시 객체를 가지도록 만들었습니다.

```java
package com.example.masterplanbbe.domain.exam.request;

public record ExamCreateRequest(
        LocalDate applyStartDate,
        LocalDate applyEndDate,
        LocalDate examStartDate,
        Long examDetailId
) {
    public Exam toEntity(EntityManager entityManager) {
        ExamDetail examDetail = entityManager.getReference(ExamDetail.class, examDetailId);
        return new Exam(
                examDetail,
                name,
                participantCount,
                applyStartDate,
                applyEndDate,
                examStartDate
        );
    }
}
```

* 이외에는 테스트를 작성했습니다.